### PR TITLE
Fix off-by-one error in CoNLL dataset

### DIFF
--- a/datasets/conll2003/conll2003.py
+++ b/datasets/conll2003/conll2003.py
@@ -237,7 +237,7 @@ class Conll2003(datalabs.GeneratorBasedBuilder):
         ]
 
     def _generate_examples(self, filepath):
-        logger.info("⏳ Generating examples from = %s", filepath)
+        logger.info("⏳ Generating examples from = %s\n", filepath)
         with open(filepath, encoding="utf-8") as f:
             guid = 0
             tokens = []
@@ -266,8 +266,9 @@ class Conll2003(datalabs.GeneratorBasedBuilder):
                         tags.append(splits[3].rstrip())
 
             # last example
-            yield guid, {
-                "id": str(guid),
-                "tokens": tokens,
-                "tags": tags,
-            }
+            if len(tokens) != 0:
+                yield guid, {
+                    "id": str(guid),
+                    "tokens": tokens,
+                    "tags": tags,
+                }


### PR DESCRIPTION
The CoNLL dataset was returning an extra empty sentence at the end. This PR fixes this.