### PR TITLE
Updated Gaokao answers column

### DIFF
--- a/datasets/gaokao2018_np1/gaokao2018_np1.py
+++ b/datasets/gaokao2018_np1/gaokao2018_np1.py
@@ -134,7 +134,7 @@ class Gaokao2018NP1(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),

--- a/datasets/gaokao2018_np3/gaokao2018_np3.py
+++ b/datasets/gaokao2018_np3/gaokao2018_np3.py
@@ -134,7 +134,7 @@ class Gaokao2018NP3(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),

--- a/datasets/gaokao2019_np1/gaokao2019_np1.py
+++ b/datasets/gaokao2019_np1/gaokao2019_np1.py
@@ -134,7 +134,7 @@ class Gaokao2019NP1(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),

--- a/datasets/gaokao2019_np2/gaokao2019_np2.py
+++ b/datasets/gaokao2019_np2/gaokao2019_np2.py
@@ -134,7 +134,7 @@ class Gaokao2019NP2(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),

--- a/datasets/gaokao2019_np3/gaokao2019_np3.py
+++ b/datasets/gaokao2019_np3/gaokao2019_np3.py
@@ -134,7 +134,7 @@ class Gaokao2019NP3(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),

--- a/datasets/gaokao2020_np1/gaokao2020_np1.py
+++ b/datasets/gaokao2020_np1/gaokao2020_np1.py
@@ -134,7 +134,7 @@ class Gaokao2020NP1(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),

--- a/datasets/gaokao2020_np2/gaokao2020_np2.py
+++ b/datasets/gaokao2020_np2/gaokao2020_np2.py
@@ -134,7 +134,7 @@ class Gaokao2020NP2(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),

--- a/datasets/gaokao2020_np3/gaokao2020_np3.py
+++ b/datasets/gaokao2020_np3/gaokao2020_np3.py
@@ -134,7 +134,7 @@ class Gaokao2020NP3(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),

--- a/datasets/gaokao2021_npa/gaokao2021_npa.py
+++ b/datasets/gaokao2021_npa/gaokao2021_npa.py
@@ -134,7 +134,7 @@ class Gaokao2021NPA(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),

--- a/datasets/gaokao2021_npb/gaokao2021_npb.py
+++ b/datasets/gaokao2021_npb/gaokao2021_npb.py
@@ -134,7 +134,7 @@ class Gaokao2021NPB(datalabs.GeneratorBasedBuilder):
                     context_column="context",
                     options_column="options",
                     question_column="question_mark",
-                    answers_column="answer",
+                    answers_column="answers",
                 )
             ],
         ),


### PR DESCRIPTION
It seems that Gaokao's answers column had the wrong name in some cases, which was breaking explainaboard.