### PR TITLE
Adding annotated test sets for NQ, TriviaQA and WebQ datasets

### DIFF
--- a/datasets/natural_questions_comp_gen/natural_questions_comp_gen.py
+++ b/datasets/natural_questions_comp_gen/natural_questions_comp_gen.py
@@ -1,0 +1,133 @@
+# coding=utf-8
+# Copyright 2022 The TensorFlow datasets Authors and the HuggingFace datasets, DataLab Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""SQUAD: The Stanford Question Answering Dataset."""
+
+
+import json
+import datalabs
+from datalabs import get_task, TaskType
+
+logger = datalabs.logging.get_logger(__name__)
+
+
+_CITATION = """\
+@article{liu2021challenges,
+  title={Challenges in generalization in open domain question answering},
+  author={Liu, Linqing and Lewis, Patrick and Riedel, Sebastian and Stenetorp, Pontus},
+  journal={arXiv preprint arXiv:2109.01156},
+  year={2021}
+}
+"""
+
+_DESCRIPTION = """\
+Drawing upon studies on systematic generalization, we introduce and annotate \
+questions according to three categories that measure different \
+levels and kinds of generalization: \
+training set overlap, compositional generalization (comp-gen), \
+and novel-entity generalization (novel-entity).
+"""
+
+
+TEST_URL = 'https://raw.githubusercontent.com/likicode/QA-generalize/master/annotations/qa_data_with_annotations/nq_test.json'
+
+class NQConfig(datalabs.BuilderConfig):
+    """BuilderConfig for SQUAD."""
+
+    def __init__(self, **kwargs):
+        """BuilderConfig for Natural Questions test set annotations.
+
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
+        super(NQConfig, self).__init__(**kwargs)
+
+
+class NQ(datalabs.GeneratorBasedBuilder):
+    """Natural Questions dataset with compositional generalization annotations."""
+
+    BUILDER_CONFIGS = [
+        NQConfig(
+            name="overlap",
+            description="overlapped with questions in the training set.",
+        ),
+        NQConfig(
+            name="comp_gen",
+            description="novel compositions of previously observed entities and structures.",
+            ),
+        NQConfig(
+            name="novel_entity",
+            description="consists of entities not present in the training set.",
+            )
+    ]
+
+    def _info(self):
+        return datalabs.DatasetInfo(
+            description=_DESCRIPTION,
+            features=datalabs.Features(
+                {
+                    "id": datalabs.Value("string"),
+                    "question": datalabs.Value("string"),
+                    "answers": datalabs.features.Sequence(datalabs.Value("string")),
+                    "labels": datalabs.features.Sequence(datalabs.Value("string"))
+                }
+            ),
+            # No default supervised_keys (as we have to pass both question
+            # and context as input).
+            supervised_keys=None,
+            homepage="https://github.com/likicode/QA-generalize/",
+            citation=_CITATION,
+            task_templates=[
+                get_task(TaskType.qa_open_domain)(
+                    question_column="question",
+                    answers_column="answers",
+                )
+            ],
+        )
+
+
+    def _split_generators(self, dl_manager):
+
+        test_path = dl_manager.download_and_extract(TEST_URL)
+
+        return [datalabs.SplitGenerator(
+                name=datalabs.Split.TEST,
+                gen_kwargs={"filepath": test_path})]
+        
+
+
+    def _generate_examples(self, filepath):
+        """This function returns the examples in the json form."""
+        print("generating examples from = %s", filepath)
+        key = 0
+        with open(filepath, 'rb') as f:
+            nq = json.load(f)
+
+        if self.config.name == 'overlap':
+            selected_groups = [item for item in nq if item['labels'] == ['overlap']]
+        elif self.config.name == 'comp_gen':
+            selected_groups = [item for item in nq if item['labels'] == ['comp_gen']]
+        elif self.config.name == 'novel_entity':
+            selected_groups = [item for item in nq if item['labels'] == ['novel_entity']]
+
+        for line in selected_groups:
+            yield key, {
+                'id': line['id'],
+                'question': line['question'],
+                'answers': line['answers'],
+                'labels': line["labels"]
+            }
+            key += 1

--- a/datasets/natural_questions_comp_gen/task_odqa_generalization.md
+++ b/datasets/natural_questions_comp_gen/task_odqa_generalization.md
@@ -1,0 +1,36 @@
+# Analyzing the Generalization of Open Domain Question Answering
+
+In this file we describe how to analyze the generalization of models trained on open domain question answering datasets, for example [`natural questions`](https://github.com/google-research-datasets/natural-questions).
+
+
+
+## Data Preparation
+
+In order to perform analysis of your results, the predicted answers should be in the following
+text format:
+
+```
+william henry bragg
+may 18, 2018
+...
+```
+where each line is an answer prediction.
+
+An example system output file is here:
+* [test.dpr.nq.txt](https://github.com/likicode/QA-generalize/blob/master/predictions/test.dpr.nq.txt) 
+
+## Performing Basic Analysis
+
+
+The below example loads the `natural_questions_comp_gen` dataset from DataLab. 
+
+```shell
+explainaboard --task qa_open_domain --dataset natural_questions_comp_gen --system_outputs MY_FILE > report.json
+```
+
+* `--task`: denotes the task name.
+* `--system_outputs`: denote the path of system outputs. Multiple one should be
+  separated by space, for example, system1 system2
+* `--dataset`:optional, denotes the dataset name
+* `report.json`: the generated analysis file with json format. . Tips: use a json viewer
+  like [this one](http://jsonviewer.stack.hu/) for better interpretation.

--- a/datasets/triviaqa_comp_gen/triviaqa_comp_gen.py
+++ b/datasets/triviaqa_comp_gen/triviaqa_comp_gen.py
@@ -1,0 +1,133 @@
+# coding=utf-8
+# Copyright 2022 The TensorFlow datasets Authors and the HuggingFace datasets, DataLab Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""SQUAD: The Stanford Question Answering Dataset."""
+
+
+import json
+import datalabs
+from datalabs import get_task, TaskType
+
+logger = datalabs.logging.get_logger(__name__)
+
+
+_CITATION = """\
+@article{liu2021challenges,
+  title={Challenges in generalization in open domain question answering},
+  author={Liu, Linqing and Lewis, Patrick and Riedel, Sebastian and Stenetorp, Pontus},
+  journal={arXiv preprint arXiv:2109.01156},
+  year={2021}
+}
+"""
+
+_DESCRIPTION = """\
+Drawing upon studies on systematic generalization, we introduce and annotate \
+questions according to three categories that measure different \
+levels and kinds of generalization: \
+training set overlap, compositional generalization (comp-gen), \
+and novel-entity generalization (novel-entity).
+"""
+
+
+TEST_URL = 'https://raw.githubusercontent.com/likicode/QA-generalize/master/annotations/qa_data_with_annotations/tqa_test_subset.json'
+
+class TriviaQAConfig(datalabs.BuilderConfig):
+    """BuilderConfig for SQUAD."""
+
+    def __init__(self, **kwargs):
+        """BuilderConfig for Natural Questions test set annotations.
+
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
+        super(TriviaQAConfig, self).__init__(**kwargs)
+
+
+class TriviaQA(datalabs.GeneratorBasedBuilder):
+    """Natural Questions dataset with compositional generalization annotations."""
+
+    BUILDER_CONFIGS = [
+        TriviaQAConfig(
+            name="overlap",
+            description="overlapped with questions in the training set.",
+        ),
+        TriviaQAConfig(
+            name="comp_gen",
+            description="novel compositions of previously observed entities and structures.",
+            ),
+        TriviaQAConfig(
+            name="novel_entity",
+            description="consists of entities not present in the training set.",
+            )
+    ]
+
+    def _info(self):
+        return datalabs.DatasetInfo(
+            description=_DESCRIPTION,
+            features=datalabs.Features(
+                {
+                    "id": datalabs.Value("string"),
+                    "question": datalabs.Value("string"),
+                    "answers": datalabs.features.Sequence(datalabs.Value("string")),
+                    "labels": datalabs.features.Sequence(datalabs.Value("string"))
+                }
+            ),
+            # No default supervised_keys (as we have to pass both question
+            # and context as input).
+            supervised_keys=None,
+            homepage="https://github.com/likicode/QA-generalize/",
+            citation=_CITATION,
+            task_templates=[
+                get_task(TaskType.qa_open_domain)(
+                    question_column="question",
+                    answers_column="answers",
+                )
+            ],
+        )
+
+
+    def _split_generators(self, dl_manager):
+
+        test_path = dl_manager.download_and_extract(TEST_URL)
+
+        return [datalabs.SplitGenerator(
+                name=datalabs.Split.TEST,
+                gen_kwargs={"filepath": test_path})]
+        
+
+
+    def _generate_examples(self, filepath):
+        """This function returns the examples in the json form."""
+        print("generating examples from = %s", filepath)
+        key = 0
+        with open(filepath, 'rb') as f:
+            triviaqa = json.load(f)
+
+        if self.config.name == 'overlap':
+            selected_groups = [item for item in triviaqa if item['labels'] == ['overlap']]
+        elif self.config.name == 'comp_gen':
+            selected_groups = [item for item in triviaqa if item['labels'] == ['comp_gen']]
+        elif self.config.name == 'novel_entity':
+            selected_groups = [item for item in triviaqa if item['labels'] == ['novel_entity']]
+
+        for line in selected_groups:
+            yield key, {
+                'id': line['id'],
+                'question': line['question'],
+                'answers': line['answers'],
+                'labels': line["labels"]
+            }
+            key += 1

--- a/datasets/webquestion_comp_gen/webquestion_comp_gen.py
+++ b/datasets/webquestion_comp_gen/webquestion_comp_gen.py
@@ -1,0 +1,133 @@
+# coding=utf-8
+# Copyright 2022 The TensorFlow datasets Authors and the HuggingFace datasets, DataLab Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""SQUAD: The Stanford Question Answering Dataset."""
+
+
+import json
+import datalabs
+from datalabs import get_task, TaskType
+
+logger = datalabs.logging.get_logger(__name__)
+
+
+_CITATION = """\
+@article{liu2021challenges,
+  title={Challenges in generalization in open domain question answering},
+  author={Liu, Linqing and Lewis, Patrick and Riedel, Sebastian and Stenetorp, Pontus},
+  journal={arXiv preprint arXiv:2109.01156},
+  year={2021}
+}
+"""
+
+_DESCRIPTION = """\
+Drawing upon studies on systematic generalization, we introduce and annotate \
+questions according to three categories that measure different \
+levels and kinds of generalization: \
+training set overlap, compositional generalization (comp-gen), \
+and novel-entity generalization (novel-entity).
+"""
+
+
+TEST_URL = 'https://raw.githubusercontent.com/likicode/QA-generalize/master/annotations/qa_data_with_annotations/webq_test.json'
+
+class WebQConfig(datalabs.BuilderConfig):
+    """BuilderConfig for SQUAD."""
+
+    def __init__(self, **kwargs):
+        """BuilderConfig for Natural Questions test set annotations.
+
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
+        super(WebQConfig, self).__init__(**kwargs)
+
+
+class WebQ(datalabs.GeneratorBasedBuilder):
+    """Natural Questions dataset with compositional generalization annotations."""
+
+    BUILDER_CONFIGS = [
+        WebQConfig(
+            name="overlap",
+            description="overlapped with questions in the training set.",
+        ),
+        WebQConfig(
+            name="comp_gen",
+            description="novel compositions of previously observed entities and structures.",
+            ),
+        WebQConfig(
+            name="novel_entity",
+            description="consists of entities not present in the training set.",
+            )
+    ]
+
+    def _info(self):
+        return datalabs.DatasetInfo(
+            description=_DESCRIPTION,
+            features=datalabs.Features(
+                {
+                    "id": datalabs.Value("string"),
+                    "question": datalabs.Value("string"),
+                    "answers": datalabs.features.Sequence(datalabs.Value("string")),
+                    "labels": datalabs.features.Sequence(datalabs.Value("string"))
+                }
+            ),
+            # No default supervised_keys (as we have to pass both question
+            # and context as input).
+            supervised_keys=None,
+            homepage="https://github.com/likicode/QA-generalize/",
+            citation=_CITATION,
+            task_templates=[
+                get_task(TaskType.qa_open_domain)(
+                    question_column="question",
+                    answers_column="answers",
+                )
+            ],
+        )
+
+
+    def _split_generators(self, dl_manager):
+
+        test_path = dl_manager.download_and_extract(TEST_URL)
+
+        return [datalabs.SplitGenerator(
+                name=datalabs.Split.TEST,
+                gen_kwargs={"filepath": test_path})]
+        
+
+
+    def _generate_examples(self, filepath):
+        """This function returns the examples in the json form."""
+        print("generating examples from = %s", filepath)
+        key = 0
+        with open(filepath, 'rb') as f:
+            webq = json.load(f)
+
+        if self.config.name == 'overlap':
+            selected_groups = [item for item in webq if item['labels'] == ['overlap']]
+        elif self.config.name == 'comp_gen':
+            selected_groups = [item for item in webq if item['labels'] == ['comp_gen']]
+        elif self.config.name == 'novel_entity':
+            selected_groups = [item for item in webq if item['labels'] == ['novel_entity']]
+
+        for line in selected_groups:
+            yield key, {
+                'id': line['id'],
+                'question': line['question'],
+                'answers': line['answers'],
+                'labels': line["labels"]
+            }
+            key += 1


### PR DESCRIPTION
This is the annotated ODQA dataset for the paper "Challenges in Generalization in Open Domain Question Answering" (https://github.com/likicode/QA-generalize).

I created three directories containing each dataset individually: 
- datasets/natural_questions_comp_gen
- datasets/triviaqa_comp_gen
- datasets/webquestion_comp_gen

**Unfinished:**
There is one example [system outputs for explanaboard](https://github.com/neulab/ExplainaBoard/blob/main/docs/task_extractive_qa.md) under `datasets/natural_questions_comp_gen`. I don't know how to handle the cases where each test example is associated with three labels (overlap / comp_gen / novel_entity). Please help! : )
