### PR TITLE
Use logger.info() consistently

### DIFF
--- a/datasets/natural_questions_comp_gen/natural_questions_comp_gen.py
+++ b/datasets/natural_questions_comp_gen/natural_questions_comp_gen.py
@@ -111,7 +111,7 @@ class NQ(datalabs.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath):
         """This function returns the examples in the json form."""
-        print("generating examples from = %s", filepath)
+        logger.info("generating examples from = %s", filepath)
         key = 0
         with open(filepath, 'rb') as f:
             nq = json.load(f)

--- a/datasets/triviaqa_comp_gen/triviaqa_comp_gen.py
+++ b/datasets/triviaqa_comp_gen/triviaqa_comp_gen.py
@@ -111,7 +111,7 @@ class TriviaQA(datalabs.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath):
         """This function returns the examples in the json form."""
-        print("generating examples from = %s", filepath)
+        logger.info("generating examples from = %s", filepath)
         key = 0
         with open(filepath, 'rb') as f:
             triviaqa = json.load(f)

--- a/datasets/webquestion_comp_gen/webquestion_comp_gen.py
+++ b/datasets/webquestion_comp_gen/webquestion_comp_gen.py
@@ -111,7 +111,7 @@ class WebQ(datalabs.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath):
         """This function returns the examples in the json form."""
-        print("generating examples from = %s", filepath)
+        logger.info("generating examples from = %s", filepath)
         key = 0
         with open(filepath, 'rb') as f:
             webq = json.load(f)


### PR DESCRIPTION
Most scripts that download datasets log messages with "generating examples from" using `logger.info()`, but the following three scripts use `print` (and `%s` is used incorrectly). This makes users of this package get confused because messages shown by `print` doesn't tell users the source of the messages. In fact, when running tests in ExplainaBoard in CI, these messages are shown. This PR fixes the inconsistency.

```
datasets/natural_questions_comp_gen/natural_questions_comp_gen.py
datasets/triviaqa_comp_gen/triviaqa_comp_gen.py
datasets/webquestion_comp_gen/webquestion_comp_gen.py
```