### PR TITLE
Remove printing paths to datasets

### DIFF
--- a/datasets/ag_news/ag_news.py
+++ b/datasets/ag_news/ag_news.py
@@ -84,7 +84,6 @@ class AGNews(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
         return [
             datalabs.SplitGenerator(

--- a/datasets/asap_review/asap_review.py
+++ b/datasets/asap_review/asap_review.py
@@ -87,11 +87,8 @@ class ASAPReviewDataset(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         val_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
-        print(f"validation_path: \t{val_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"test_path: \t{test_path}")
 
         return [
             datalabs.SplitGenerator(

--- a/datasets/atis/atis.py
+++ b/datasets/atis/atis.py
@@ -93,7 +93,6 @@ class ATIS(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
         return [
             datalabs.SplitGenerator(

--- a/datasets/chnsenticorp_hotel/chnsenticorp_hotel.py
+++ b/datasets/chnsenticorp_hotel/chnsenticorp_hotel.py
@@ -81,7 +81,6 @@ class ChnSentiCorpHotel(datalabs.GeneratorBasedBuilder):
         validation_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
 
-        print(f"train_path: \t{train_path}")
         return [
             datalabs.SplitGenerator(name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}),
             datalabs.SplitGenerator(name=datalabs.Split.VALIDATION, gen_kwargs={"filepath": validation_path}),

--- a/datasets/codeswitch_bangor/codeswitch_bangor.py
+++ b/datasets/codeswitch_bangor/codeswitch_bangor.py
@@ -87,11 +87,8 @@ class CodeSwitchBangor(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         validation_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
-        print(f"validation_path: \t{validation_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"test_path: \t{test_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/cr/cr.py
+++ b/datasets/cr/cr.py
@@ -69,9 +69,7 @@ class CR(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"test_path: \t{test_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/dont_stop_pretraining/dont_stop_pretraining.py
+++ b/datasets/dont_stop_pretraining/dont_stop_pretraining.py
@@ -182,15 +182,12 @@ class DontStopPretraining(datalabs.GeneratorBasedBuilder):
         train_path = dl_manager.download_and_extract(
             f"{_BASE_URL}/{self.config.name}/train.jsonl"
         )
-        print(f"train_path: \t{train_path}")
         dev_path = dl_manager.download_and_extract(
             f"{_BASE_URL}/{self.config.name}/dev.jsonl"
         )
-        print(f"dev_path: \t{dev_path}")
         test_path = dl_manager.download_and_extract(
             f"{_BASE_URL}/{self.config.name}/test.jsonl"
         )
-        print(f"test_path: \t{test_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/laptop14/laptop14.py
+++ b/datasets/laptop14/laptop14.py
@@ -70,9 +70,7 @@ class Laptop14(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"test_path: \t{test_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/mr/mr.py
+++ b/datasets/mr/mr.py
@@ -106,7 +106,6 @@ class MR(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
         return [
             datalabs.SplitGenerator(

--- a/datasets/nlpcc14_sc/nlpcc14_sc.py
+++ b/datasets/nlpcc14_sc/nlpcc14_sc.py
@@ -70,8 +70,6 @@ class NLPCC14SC(datalabs.GeneratorBasedBuilder):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
         valid_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        
-        print(f"train_path: \t{train_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/onlineshopping/onlineshopping.py
+++ b/datasets/onlineshopping/onlineshopping.py
@@ -88,7 +88,6 @@ class OnlineShopping(datalabs.GeneratorBasedBuilder):
         valid_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
 
-        print(f"train_path: \t{train_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/qc/qc.py
+++ b/datasets/qc/qc.py
@@ -68,7 +68,6 @@ class QC(datalabs.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/restaurant14/restaurant14.py
+++ b/datasets/restaurant14/restaurant14.py
@@ -70,9 +70,7 @@ class Restaurant14(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"test_path: \t{test_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/restaurant16/restaurant16.py
+++ b/datasets/restaurant16/restaurant16.py
@@ -56,9 +56,7 @@ class Restaurant16(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"test_path: \t{test_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/se_absa16_came/se_absa16_came.py
+++ b/datasets/se_absa16_came/se_absa16_came.py
@@ -95,7 +95,6 @@ class SEABSA16CAME(datalabs.GeneratorBasedBuilder):
         valid_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
 
-        print(f"train_path: \t{train_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/se_absa16_phns/se_absa16_phns.py
+++ b/datasets/se_absa16_phns/se_absa16_phns.py
@@ -99,7 +99,6 @@ class SEABSA16PHNS(datalabs.GeneratorBasedBuilder):
         valid_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
 
-        print(f"train_path: \t{train_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/sst2/sst2.py
+++ b/datasets/sst2/sst2.py
@@ -76,11 +76,8 @@ class SST2(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         validation_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
-        print(f"validation_path: \t{validation_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"test_path: \t{test_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/sst5/sst5.py
+++ b/datasets/sst5/sst5.py
@@ -82,9 +82,7 @@ class SST5(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"test_path: \t{test_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/subj/subj.py
+++ b/datasets/subj/subj.py
@@ -66,7 +66,6 @@ class SUBJ(datalabs.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/twitter/twitter.py
+++ b/datasets/twitter/twitter.py
@@ -70,9 +70,7 @@ class Twitter(datalabs.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
-        print(f"test_path: \t{test_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/wcm2/wcm2.py
+++ b/datasets/wcm2/wcm2.py
@@ -131,11 +131,8 @@ class WCM2(datalabs.GeneratorBasedBuilder):
         lang = str(self.config.name)
 
         train_path = dl_manager.download_and_extract(_TRAIN_DOWNLOAD_URL)
-        print(f"train_path: \t{train_path}")
         validation_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
-        print(f"validation_path: \t{validation_path}")
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL[lang])
-        print(f"test_path: \t{test_path}")
 
         return [
             datalabs.SplitGenerator(

--- a/datasets/weibo_4moods/weibo_4moods.py
+++ b/datasets/weibo_4moods/weibo_4moods.py
@@ -87,7 +87,6 @@ class Weibo4Moods(datalabs.GeneratorBasedBuilder):
         valid_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
 
-        print(f"train_path: \t{train_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}

--- a/datasets/weibo_senti/weibo_senti.py
+++ b/datasets/weibo_senti/weibo_senti.py
@@ -72,7 +72,6 @@ class WeiboSenti(datalabs.GeneratorBasedBuilder):
         valid_path = dl_manager.download_and_extract(_VALIDATION_DOWNLOAD_URL)
         test_path = dl_manager.download_and_extract(_TEST_DOWNLOAD_URL)
 
-        print(f"train_path: \t{train_path}")
         return [
             datalabs.SplitGenerator(
                 name=datalabs.Split.TRAIN, gen_kwargs={"filepath": train_path}


### PR DESCRIPTION
Currently, API in `datalabs` to download datasets print paths to train, dev, validation, and test datasets using `print`. This might be useful for developers of `datalabs` to debug during development, but that makes the output of tests in CI confusing when the API is used in tests. Below is an example of screenshot of the output of tests in ExplainaBoard:

<img width="1107" alt="Screen Shot 2022-08-24 at 20 58 53" src="https://user-images.githubusercontent.com/1183444/186413050-559aad4a-36b9-4292-b8d2-ad630e0eea83.png">

After `unittest` module shows the message `OK` to console, the paths to train, validation, test datasets are printed by this `datalabs`, which is confusing for most users. It's better to avoid showing uninteresting information to users.
