### PR TITLE
Remove cache directory if it has incorrect data.

### DIFF
--- a/datalabs/utils/file_utils.py
+++ b/datalabs/utils/file_utils.py
@@ -826,3 +826,18 @@ def readline(f: io.RawIOBase):
         if res.endswith(b"\n"):
             break
     return bytes(res)
+
+
+def rmdir(root_path: str) -> None:
+    """Recursively removes a directory."""
+    root = Path(root_path)
+    if not root.exists():
+        return
+
+    for item in root.iterdir():
+        if item.is_dir():
+            rmdir(item)
+        else:
+            item.unlink()
+
+    root.rmdir()


### PR DESCRIPTION
This pull request adds a behavior to remove a cache directory in case it has incorrect data, to force re-generating a new cache.

Sometimes cache directories get broken due to updating the library (e.g., changing the `TaskType` definition) but the current implementation does not recognize if the cache follows the correct convention or not. This change may improve the robustness of the behavior around the cache.