### PR TITLE
Disable tqdm progress bar when verbosity >= WARNING

### DIFF
--- a/datalabs/arrow_dataset.py
+++ b/datalabs/arrow_dataset.py
@@ -2892,7 +2892,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin, TextData
             )
 
         disable_tqdm = (
-            bool(logging.get_verbosity() == logging.NOTSET)
+            bool(logging.get_verbosity() >= logging.WARNING)
             or not utils.is_progress_bar_enabled()
         )
 
@@ -4718,7 +4718,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin, TextData
                 file_shards_to_delete,
                 desc="Deleting unused files from dataset repository",
                 total=len(file_shards_to_delete),
-                disable=bool(logging.get_verbosity() == logging.NOTSET)
+                disable=bool(logging.get_verbosity() >= logging.WARNING)
                 or not utils.is_progress_bar_enabled(),
             ):
                 delete_file(file)
@@ -4727,7 +4727,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin, TextData
             enumerate(shards),
             desc="Pushing dataset shards to the dataset hub",
             total=num_shards,
-            disable=bool(logging.get_verbosity() == logging.NOTSET),
+            disable=bool(logging.get_verbosity() >= logging.WARNING),
         ):
             buffer = BytesIO()
             shard.to_parquet(buffer)

--- a/datalabs/arrow_writer.py
+++ b/datalabs/arrow_writer.py
@@ -740,7 +740,7 @@ def parquet_to_arrow(sources, destination):
     """Convert parquet files to arrow file. Inputs can be str paths or
     file-like objects"""
     stream = None if isinstance(destination, str) else destination
-    disable = bool(logging.get_verbosity() == logging.NOTSET)
+    disable = bool(logging.get_verbosity() >= logging.WARNING)
     with ArrowWriter(path=destination, stream=stream) as writer:
         for source in utils.tqdm(sources, unit="sources", disable=disable):
             pf = pa.parquet.ParquetFile(source)

--- a/datalabs/builder.py
+++ b/datalabs/builder.py
@@ -1326,7 +1326,7 @@ class GeneratorBasedBuilder(DatasetBuilder):
                     unit=" examples",
                     total=split_info.num_examples,
                     leave=False,
-                    disable=bool(logging.get_verbosity() == logging.NOTSET),
+                    disable=bool(logging.get_verbosity() >= logging.WARNING),
                 ):
                     example = self.info.features.encode_example(record)
                     writer.write(example, key)
@@ -1388,7 +1388,7 @@ class ArrowBasedBuilder(DatasetBuilder):
                 generator,
                 unit=" tables",
                 leave=False,
-                disable=True,  # bool(logging.get_verbosity() == logging.NOTSET)
+                disable=True,  # bool(logging.get_verbosity() >= logging.WARNING)
             ):
                 writer.write_table(table)
             num_examples, num_bytes = writer.finalize()

--- a/datalabs/data_files.py
+++ b/datalabs/data_files.py
@@ -589,7 +589,7 @@ def _get_origin_metadata_locally_or_by_urls(
         max_workers=max_workers,
         tqdm_class=tqdm,
         desc="Resolving data files",
-        disable=len(data_files) <= 16 or logging.get_verbosity() == logging.NOTSET,
+        disable=len(data_files) <= 16 or logging.get_verbosity() >= logging.WARNING,
     )
 
 

--- a/datalabs/io/csv.py
+++ b/datalabs/io/csv.py
@@ -132,7 +132,7 @@ class CsvDatasetWriter:
             for offset in utils.tqdm(
                 range(0, len(self.dataset), self.batch_size),
                 unit="ba",
-                disable=bool(logging.get_verbosity() == logging.NOTSET),
+                disable=bool(logging.get_verbosity() >= logging.WARNING),
                 desc="Creating CSV from Arrow format",
             ):
                 csv_str = self._batch_csv((offset, header, to_csv_kwargs))
@@ -150,7 +150,7 @@ class CsvDatasetWriter:
                     ),
                     total=(len(self.dataset) // self.batch_size) + 1,
                     unit="ba",
-                    disable=bool(logging.get_verbosity() == logging.NOTSET),
+                    disable=bool(logging.get_verbosity() >= logging.WARNING),
                     desc="Creating CSV from Arrow format",
                 ):
                     written += file_obj.write(csv_str)

--- a/datalabs/io/json.py
+++ b/datalabs/io/json.py
@@ -152,7 +152,7 @@ class JsonDatasetWriter:
             for offset in utils.tqdm(
                 range(0, len(self.dataset), self.batch_size),
                 unit="ba",
-                disable=bool(logging.get_verbosity() == logging.NOTSET),
+                disable=bool(logging.get_verbosity() >= logging.WARNING),
                 desc="Creating json from Arrow format",
             ):
                 json_str = self._batch_json((offset, orient, lines, to_json_kwargs))
@@ -169,7 +169,7 @@ class JsonDatasetWriter:
                     ),
                     total=(len(self.dataset) // self.batch_size) + 1,
                     unit="ba",
-                    disable=bool(logging.get_verbosity() == logging.NOTSET),
+                    disable=bool(logging.get_verbosity() >= logging.WARNING),
                     desc="Creating json from Arrow format",
                 ):
                     written += file_obj.write(json_str)

--- a/datalabs/search.py
+++ b/datalabs/search.py
@@ -196,7 +196,7 @@ class ElasticSearchIndex(BaseIndex):
         progress = utils.tqdm(
             unit="docs",
             total=number_of_docs,
-            disable=bool(logging.get_verbosity() == logging.NOTSET),
+            disable=bool(logging.get_verbosity() >= logging.WARNING),
         )
         successes = 0
 
@@ -386,7 +386,7 @@ class FaissIndex(BaseIndex):
         logger.info(f"Adding {len(vectors)} vectors to the faiss index")
         for i in utils.tqdm(
             range(0, len(vectors), batch_size),
-            disable=bool(logging.get_verbosity() == logging.NOTSET),
+            disable=bool(logging.get_verbosity() >= logging.WARNING),
         ):
             vecs = (
                 vectors[i : i + batch_size]

--- a/datalabs/utils/file_utils.py
+++ b/datalabs/utils/file_utils.py
@@ -536,7 +536,7 @@ def http_get(
         total=total,
         initial=resume_size,
         desc="Downloading",
-        disable=bool(logging.get_verbosity() == logging.NOTSET),
+        disable=bool(logging.get_verbosity() >= logging.WARNING),
     )
     for chunk in response.iter_content(chunk_size=1024):
         if chunk:  # filter out keep-alive new chunks

--- a/datalabs/utils/py_utils.py
+++ b/datalabs/utils/py_utils.py
@@ -298,7 +298,7 @@ def map_nested(
 
     disable_tqdm = (
         disable_tqdm
-        or bool(logging.get_verbosity() == logging.NOTSET)
+        or bool(logging.get_verbosity() >= logging.WARNING)
         or not utils.is_progress_bar_enabled()
     )
     iterable = (

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name="datalabs",
-    version="0.4.10",
+    version="0.4.11",
     description="Datalabs",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR changes the condition to disable tqdm progress bar to make logging from this package more quiet so that users of this package can easily notice more severe logs. Showing progress report is useful for debugging, but it needs to be avoided when the log level (severity) is larger than or equal to WARNING (See the [logging tutorial](https://docs.python.org/3/howto/logging.html#when-to-use-logging)). Currently, the progress bar is disabled when the level is `NOTSET`, but `NOTSET` should be used when logging all messages, as per the [documentation](https://docs.python.org/3/library/logging.html#logging.Logger.setLevel). When the progress report is printed at the inappropriate levels, it is more time-consuming for users of the package to find more severe logs, as observed in  integration tests in Explainaboard (neulab/ExplainaBoard#471).