### PR TITLE
Make wget output less verbose for CI

### DIFF
--- a/datasets/bigpatent/bigpatent.py
+++ b/datasets/bigpatent/bigpatent.py
@@ -43,6 +43,7 @@ def custom_download(url, path):
         response = subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--save-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 f"{url}",
@@ -63,6 +64,7 @@ def custom_download(url, path):
         subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--load-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 "-O",

--- a/datasets/cnn_dailymail/cnn_dailymail.py
+++ b/datasets/cnn_dailymail/cnn_dailymail.py
@@ -91,6 +91,7 @@ def custom_download(url, path):
         response = subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--save-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 f"{url}",
@@ -111,6 +112,7 @@ def custom_download(url, path):
         subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--load-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 "-O",

--- a/datasets/govreport/govreport.py
+++ b/datasets/govreport/govreport.py
@@ -51,6 +51,7 @@ def custom_download(url, path):
         response = subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--save-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 f"{url}",
@@ -71,6 +72,7 @@ def custom_download(url, path):
         subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--load-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 "-O",

--- a/datasets/multinews/multinews.py
+++ b/datasets/multinews/multinews.py
@@ -47,6 +47,7 @@ def custom_download(url, path):
         response = subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--save-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 f"{url}",
@@ -67,6 +68,7 @@ def custom_download(url, path):
         subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--load-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 "-O",

--- a/datasets/reddit_tifu/reddit_tifu.py
+++ b/datasets/reddit_tifu/reddit_tifu.py
@@ -41,6 +41,7 @@ def custom_download(url, path):
         response = subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--save-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 f"{url}",
@@ -61,6 +62,7 @@ def custom_download(url, path):
         subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--load-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 "-O",

--- a/datasets/wikihow/wikihow.py
+++ b/datasets/wikihow/wikihow.py
@@ -41,6 +41,7 @@ def custom_download(url, path):
         response = subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--save-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 f"{url}",
@@ -61,6 +62,7 @@ def custom_download(url, path):
         subprocess.check_output(
             [
                 "wget",
+                "--progress=dot:giga",
                 "--load-cookies",
                 os.path.join(tmpdir, "cookies.txt"),
                 "-O",


### PR DESCRIPTION
This is the second attempt to fix neulab/ExplainaBoard#471. It turned out the root cause is that script for particular dataset invokes `wget` command directly in which the verbosity config changed in #345 has no effect for controlling the verbosity of `wget` command. We can make `wget` output less verbose by setting `--progress=dot:giga` (See the [manual of wget](https://www.gnu.org/software/wget/manual/wget.html#Download-Options) for details). Alternatively, we can turn off the output by setting `--no-verbose` which still prints error messages. If we need to reduce the output further, we can consider setting that option.
