### PR TITLE
Bump version to 0.4.12

### DIFF
--- a/datalabs/__init__.py
+++ b/datalabs/__init__.py
@@ -19,7 +19,7 @@
 # pylint: enable=line-too-long
 # pylint: disable=g-import-not-at-top,g-bad-import-order,wrong-import-position
 
-__version__ = "0.4.0"
+__version__ = "0.4.12"
 
 from packaging import version as _version
 import pyarrow

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name="datalabs",
-    version="0.4.11",
+    version="0.4.12",
     description="Datalabs",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This bumps version to 0.4.12 so that ExplainaBoard can pick up #346 in its CI.