### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owner
+* @pfliu-nlp @neubig


### PR DESCRIPTION
This PR adds `CODEOWNERS` file. This is because ExplainaBoard highly depends on DataLab. This implies that we should maintain this project such that pull requests requires code review by code owners.