### PR TITLE
Add pre-commit as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd Datalab
 pip install -e .[dev]
 python -m nltk.downloader omw-1.4 # to support more feature calculation
 ```
-By adding `[dev]`, some [extra libraries](https://github.com/ExpressAI/DataLab/blob/03f69e5424859e3e9dbcbb487d3e1ce3de45a599/setup.py#L66) will be installed, such as `pre-commit`, `black` and so on.
+By adding `[dev]`, some [extra libraries](https://github.com/ExpressAI/DataLab/blob/03f69e5424859e3e9dbcbb487d3e1ce3de45a599/setup.py#L66) will be installed, such as `pre-commit`.
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ BENCHMARKS_REQUIRE = []
 TESTS_REQUIRE = []
 
 
-QUALITY_REQUIRE = ["black==22.3.0", "flake8==4.0.1", "isort>=5.6.4"]
+QUALITY_REQUIRE = ["pre-commit"]
 
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
`README.md` indicates that `pre-commit` is installed by `pip install -e .[dev]`, but that's not true. This is because `pre-commit` is not listed in dev dependencies. This PR adds `pre-commit`. This PR also removes black, flake8, and isort from dev dependencies because these tools are managed by `pre-commit`.