### PR TITLE
Add markdownlint-cli2 to pre-commit hook and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,15 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: flake8 --all-files
+  lint-markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: lint
+        uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: markdownlint-cli2 --all-files

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,30 @@
+config:
+  # TODO(tetsuok): Re-enable once all the warnings get fixed.
+  MD001: false
+
+  # TODO(tetsuok): Re-enable once all the warnings get fixed.
+  MD013: false
+    # Number of characters
+    # line_length: 88
+    # code_blocks: false
+
+  MD024:
+    # Allow multiple headings with the same content
+    siblings_only: true
+
+  # TODO(tetsuok): Re-enable once all the warnings get fixed.
+  MD033: false
+    # Allows the following tags becasue there is no reasonable counterpart in Markdown.
+    # The <a> tag can be used to use an image as a link. The <img> tag can be used to
+    # change image size. Note that there is no standardized way to change image size in
+    # Markdown yet.
+    # allowed_elements: [a, img]
+
+  # TODO(tetsuok): Re-enable once all the warnings get fixed.
+  MD040: false
+
+  # TODO(tetsuok): Re-enable once all the warnings get fixed.
+  MD041: false
+
+  # TODO(tetsuok): Re-enable once all the warnings get fixed.
+  MD046: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
         exclude: datasets
         args: ["--profile", "black"]
         files: '\.py$'
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.5.1
+    hooks:
+    - id: markdownlint-cli2
+    - id: markdownlint-cli2-fix

--- a/README.md
+++ b/README.md
@@ -8,33 +8,29 @@
   <a href=".github/workflows/ci.yml"><img alt="Integration Tests", src="https://github.com/expressai/DataLab/actions/workflows/ci.yml/badge.svg?event=push" />
 </p>
 
-
 [DataLab](http://datalab.nlpedia.ai/) is a unified platform that allows for NLP researchers to perform a number of data-related tasks in an efficient and easy-to-use manner. In particular, DataLab supports the following functionalities:
 
-    
-
-    
-    
-<p align="center"> 
+<p align="center">
 <img src="./docs/Resources/figs/datalab_overview.png" width="300"/>
- </p> 
+ </p>
 
 * **Data Diagnostics**: DataLab allows for analysis and understanding of data to uncover undesirable traits such as hate speech, gender bias, or label imbalance.
 * **Operation Standardization**: DataLab provides and standardizes a large number of data processing operations, including aggregating, preprocessing, featurizing, editing and prompting operations.
 * **Data Search**: DataLab provides a semantic dataset search tool to help identify appropriate datasets given a textual description of an idea.
 * **Global Analysis**: DataLab provides tools to perform global analyses over a variety of datasets.
 
-
- 
-
 ## Installation
+
 DataLab can be installed from PyPi
+
 ```bash
 pip install --upgrade pip
 pip install datalabs
 python -m nltk.downloader omw-1.4 # to support more feature calculation
 ```
+
 or from the source
+
 ```bash
 # This is suitable for SDK developers
 pip install --upgrade pip
@@ -43,11 +39,11 @@ cd Datalab
 pip install -e .[dev]
 python -m nltk.downloader omw-1.4 # to support more feature calculation
 ```
+
 By adding `[dev]`, some [extra libraries](https://github.com/ExpressAI/DataLab/blob/03f69e5424859e3e9dbcbb487d3e1ce3de45a599/setup.py#L66) will be installed, such as `pre-commit`, `black` and so on.
 
-
-
 #### Code Quality Check?
+
 If you would like to contribute to DataLab, checking the code style and quality before your pull
 request is highly recommended. In this project, three types of checks will be expected: (a) black
 (2) flake8 (3) isort
@@ -55,21 +51,23 @@ request is highly recommended. In this project, three types of checks will be ex
 you could achieve this in two ways:
 
 ##### Manually (suitable for developers using Github Destop)
+
 ```shell
 pre-commit install
 git init .
 pre-commit run --all-files or
 ```
+
 where `pre-commit run -all-files` is equivalent to
+
 ```shell
 pre-commit run black   # (this is also equivalent to python -m black .)
 pre-commit run isort   # (this is also equivalent to isort .)
 pre-commit run flake8  # (this is  also equivalent to flake8)
 ```
+
 Notably, `black` and `isort` can help us fix code style automatically, while `flake8` only
 provide hints with us, which means we need to fix these issues raised by `flake8`.
-
-
 
 ##### Automatically (suitable for developers using Git CLI)
 
@@ -78,16 +76,18 @@ pre-commit install
 git init .
 git commit -m "your update message"
 ```
+
 The `git commit` will automatically activate the command `pre-commit run -all-files`
 
 ## Using DataLab
+
 Below we give several simple examples to showcase the usage of DataLab:
 
 You can also view documentation:
+
 * [**Online Tutorial**](https://expressai.github.io/DataLab/)
 * [**Adding Datasets to the SDK**](docs/SDK/add_new_datasets_into_sdk.md)
 * [**Adding a new Task to the SDK**](docs/SDK/add_new_task_schema.md)
-
 
 ```python
 # pip install datalabs
@@ -122,11 +122,8 @@ print(next(res))
 from aggregate.text_classification import *
 res = dataset["test"].apply(get_statistics)
 ```
- 
 
 ## Acknowledgment
+
 DataLab originated from a fork of the awesome [Huggingface Datasets](https://github.com/huggingface/datasets) and [TensorFlow Datasets](https://github.com/tensorflow/datasets). We highly thank the Huggingface/TensorFlow Datasets for building this amazing library. More details on the differences between DataLab and them can be found in the section.
 We thank Antonis Anastasopoulos for sharing the mapping data between countries and languages, and thank Alissa Ostapenko, Yulia Tsvetkov, Jie Fu, Ziyun Xu, Hiroaki Hayashi, and Zhengfu He for useful discussion and suggestions for the first version.
-
-
-

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,7 +1,5 @@
 # Datasets
 
-
-
 Add following description into the begining of your script if the script is modified by `huggingface datasets`, for example, [ag_news](https://github.com/ExpressAI/DataLab/blob/main/datasets/ag_news/ag_news.py)
 
 ```

--- a/datasets/natural_questions_comp_gen/task_odqa_generalization.md
+++ b/datasets/natural_questions_comp_gen/task_odqa_generalization.md
@@ -2,8 +2,6 @@
 
 In this file we describe how to analyze the generalization of models trained on open domain question answering datasets, for example [`natural questions`](https://github.com/google-research-datasets/natural-questions).
 
-
-
 ## Data Preparation
 
 In order to perform analysis of your results, the predicted answers should be in the following
@@ -14,15 +12,16 @@ william henry bragg
 may 18, 2018
 ...
 ```
+
 where each line is an answer prediction.
 
 An example system output file is here:
-* [test.dpr.nq.txt](https://github.com/likicode/QA-generalize/blob/master/predictions/test.dpr.nq.txt) 
+
+* [test.dpr.nq.txt](https://github.com/likicode/QA-generalize/blob/master/predictions/test.dpr.nq.txt)
 
 ## Performing Basic Analysis
 
-
-The below example loads the `natural_questions_comp_gen` dataset from DataLab. 
+The below example loads the `natural_questions_comp_gen` dataset from DataLab.
 
 ```shell
 explainaboard --task qa_open_domain --dataset natural_questions_comp_gen --system_outputs MY_FILE > report.json

--- a/datasets/stats.md
+++ b/datasets/stats.md
@@ -12,44 +12,43 @@ dataset['train']._info.task_templates
 
 ```
 
-
 #### ag_news
+
 label = ["World", "Sports", "Business", "Science and Technology"]
 
-
 #### adv_mtl
+
     textualize_label = {"1":"positive",
                          "0":"negative"}
 
-
 ##### app_reviews
+
         textualize_label = {"1":"1 star",
                                  "2":"2 stars",
                                  "3":"3 stars",
                                  "4":"4 stars",
                                  "5":"5 stars"}
 
-
-
 #### tweet_eval
+
 dataset = load_dataset("./tweet_eval","emoji")
 
-
 #### amazon_reviews_multi
+
 * a mixture of multiple languages
 
-
 #### banking77
+
 * category names contain underscore, for example `transfer_timing`
 
 #### yahoo_answers_topics
+
 * category names contain `&`, for example: 'Computers & Internet'
 
-
 #### financial_phrasebank
+
 * subset = ['sentences_allagree', 'sentences_75agree', 'sentences_66agree', 'sentences_50agree']
 
-
-
 #### GLUE
+
 * stsb: label_names = None

--- a/docs/Examples/readme.md
+++ b/docs/Examples/readme.md
@@ -1,8 +1,7 @@
 # Schema of Report
 
-
-
 ## Text Classification
+
 ```python
     res = {
             "dataset-level":{
@@ -28,8 +27,8 @@
 
 ![image](https://user-images.githubusercontent.com/59123869/149849695-615304ff-a19f-4dca-8597-c1a7bca41363.png)
 
-
 ## Text Pair Classification
+
 ```Python
     res = {
             "dataset-level":{
@@ -59,8 +58,8 @@
 
 ![image](https://user-images.githubusercontent.com/59123869/149858573-1b494181-1e1d-4ec1-9043-4c7102303a9f.png)
 
-
 ## Named Entity Recognition
+
 ```python
     res = {
         "dataset-level": {
@@ -91,10 +90,8 @@
 
 ![截屏2022-01-18 下午4 20 06](https://user-images.githubusercontent.com/24972331/149898182-96462875-afd4-4edf-9a95-bf5407abe10d.png)
 
-
-
-
 ## Summarization
+
 ```python
     res = {
         "dataset-level":{

--- a/docs/Resources/operations_info/readme.md
+++ b/docs/Resources/operations_info/readme.md
@@ -1,7 +1,7 @@
 # Information for Operations
 
+suppose that
 
-suppose that 
 ```python
  metadata =    {
         "class_type": "aggregating",
@@ -15,6 +15,7 @@ suppose that
 ```
 
 we should have
+
 ```python
 # pip install datalabs
 from datalabs import load_dataset
@@ -24,8 +25,7 @@ dataset = load_dataset("ag_news")
 res=dataset["train"].apply(get_statistics)
 ```
 
-
-Code: 
+Code:
 
 ```python
 cmd_ops = ""

--- a/docs/Resources/readme.md
+++ b/docs/Resources/readme.md
@@ -1,4 +1,1 @@
 # Introduction of Resources
-
-
-

--- a/docs/SDK/add_language_info.md
+++ b/docs/SDK/add_language_info.md
@@ -1,14 +1,12 @@
 # How to add language information of you dataset?
 
-
-Take the `ag_news` (English), for example, 
-
+Take the `ag_news` (English), for example,
 
 we just need to assign value (`List[str]`) to the variable `languages` in the `_info(self)` function.
+
 * where `str` represents the ISO code of a language, which you can obtain from this [look-up table](https://huggingface.co/languages).
 If the dataset involves multiple languages, add all of them. For example, for the Chinese-English machine translation dataset, we have
   `languages = ['en','zh']`
-
 
 ```python
     def _info(self):
@@ -29,10 +27,12 @@ If the dataset involves multiple languages, add all of them. For example, for th
 ```
 
 You can verify if the language information has been successfully added by:
+
 ```python
 from datalabs import load_dataset
 
 dataset = load_dataset("ag_news")
 print(dataset['test']._info.languages)
 ```
+
 where `dataset['test']._info` represents all metadata information of the test split.

--- a/docs/SDK/add_new_datasets_into_sdk.md
+++ b/docs/SDK/add_new_datasets_into_sdk.md
@@ -2,31 +2,30 @@
 
 We will walk through how to add a new dataset into datalab.
 
-
 ## 1. Making your raw dataset available online
+
 If your dataset already has a public link online, you can use that link.
 
 Otherwise, you'll need to put your dataset into a server with downloadable links
 (please make sure you have permission to redistribute the dataset first).
 For example, you can place your datasets in
+
 * google drive
 * google cloud
 * AWS S3
- 
- 
- 
-## 2. Create a new folder and write a data loader script.
+
+## 2. Create a new folder and write a data loader script
 
 Suppose the dataset name to be added is `cr`, we need to:
+
 * create a folder `cr` in [DataLab/datasets/](https://github.com/ExpressAI/DataLab/tree/main/datasets)
 * create a data loader script `cr.py` in the above folder, i.e., `Datalab/datasets/cr/cr.py`
 * finish the data loader script based on some provided examples:
-    * text-classification: [template](https://github.com/ExpressAI/DataLab/tree/main/datasets/cr)
-    * extractive-qa: [template](https://github.com/ExpressAI/DataLab/blob/main/datasets/squad/squad.py)
-    
-
+  * text-classification: [template](https://github.com/ExpressAI/DataLab/tree/main/datasets/cr)
+  * extractive-qa: [template](https://github.com/ExpressAI/DataLab/blob/main/datasets/squad/squad.py)
 
 ## 3. Test in your local server
+
 * enter into `Datalab/datasets` folder
 * run following python commands
 
@@ -37,53 +36,60 @@ Suppose the dataset name to be added is `cr`, we need to:
    print(dataset['train']._info.task_templates)
 ```
 
-## 4. Set up a pull request 
+## 4. Set up a pull request
+
 Once you successfully finished the above steps, if you would like to make your dataset
 public, you can set up a pull request.
 
 ## 5. Make your datasets registered
+
 Once you successfully added a new dataset, please update the the file [dataset_info_dev.jsonl](https://github.com/ExpressAI/DataLab/blob/main/utils/dataset_info_dev.jsonl)
-by conducting the following command: 
+by conducting the following command:
+
 ```shell
 python get_dataset_info.py --previous_jsonl dataset_info.jsonl --output_jsonl dataset_info_dev.jsonl
 ```
 
-
-
 ## FAQ
+
 When adding a new datasets, you probably will encounter following questions:
 
 * #### what if existing task schema can not support my current dataset?
+
 Suggested docs: [how to add_new_task_schema](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_task_schema.md)
 
 * #### how to add the language information of my dataset?
+
 Suggested doc: [how to add language information](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_language_info.md)
 
 * #### could I have more examples to help me write the script?
+
 You can find scripts for adding different datasets cross different tasks.
 Suggested doc: [more examples](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/task_normalization.md)
 
 For example,
-   * if you aim to add a simple text classification dataset:
-       * [sst2](https://github.com/ExpressAI/DataLab/blob/main/datasets/sst2/sst2.py)
-   * if you aim to add a simple summarization dataset
-       * [cnn_dailymail](https://github.com/ExpressAI/DataLab/blob/main/datasets/cnn_dailymail/cnn_dailymail.py)
-   * if you aim to add a simple natural languange inference dataset:
-       * [sick](https://github.com/ExpressAI/DataLab/blob/main/datasets/sick/sick.py)
-       * [snli](https://github.com/ExpressAI/DataLab/blob/main/datasets/snli/snli.py)
-   * if you aim to add a datasets with different versions/domains/languages/subdatasets
-       * different versions: [arxiv_sum](https://github.com/ExpressAI/DataLab/blob/main/datasets/arxiv_sum/arxiv_sum.py)
-       * different languages: [xlsum](https://github.com/ExpressAI/DataLab/blob/main/datasets/xlsum/xlsum.py), [mlqa](https://github.com/ExpressAI/DataLab/blob/main/datasets/mlqa/mlqa.py)
-       * different subtasks: [glue](https://github.com/ExpressAI/DataLab/blob/main/datasets/glue/glue.py)
 
-   * if your datasets have been packaged into a zip file, you can refer to this [example](https://github.com/ExpressAI/DataLab/blob/main/datasets/snli/snli.py)
+* if you aim to add a simple text classification dataset:
+  * [sst2](https://github.com/ExpressAI/DataLab/blob/main/datasets/sst2/sst2.py)
+* if you aim to add a simple summarization dataset
+  * [cnn_dailymail](https://github.com/ExpressAI/DataLab/blob/main/datasets/cnn_dailymail/cnn_dailymail.py)
+* if you aim to add a simple natural languange inference dataset:
+  * [sick](https://github.com/ExpressAI/DataLab/blob/main/datasets/sick/sick.py)
+  * [snli](https://github.com/ExpressAI/DataLab/blob/main/datasets/snli/snli.py)
+* if you aim to add a datasets with different versions/domains/languages/subdatasets
+  * different versions: [arxiv_sum](https://github.com/ExpressAI/DataLab/blob/main/datasets/arxiv_sum/arxiv_sum.py)
+  * different languages: [xlsum](https://github.com/ExpressAI/DataLab/blob/main/datasets/xlsum/xlsum.py), [mlqa](https://github.com/ExpressAI/DataLab/blob/main/datasets/mlqa/mlqa.py)
+  * different subtasks: [glue](https://github.com/ExpressAI/DataLab/blob/main/datasets/glue/glue.py)
 
-   * if you want to upload your dataset into DataLab web platform (which provides a bunch of data visualization and analysis), you can follow
+* if your datasets have been packaged into a zip file, you can refer to this [example](https://github.com/ExpressAI/DataLab/blob/main/datasets/snli/snli.py)
+
+* if you want to upload your dataset into DataLab web platform (which provides a bunch of data visualization and analysis), you can follow
    this [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_web_platform.md).
 
 NOTE:
+
 * Usually, using the **Lower** case string with `_` instead of `-` for the script name (`arxiv_sum.py`) while camel case for the class name (`ArxivSum`).
-   
+
 #### what if there is private data that I want to use?
 
 DataLab has a special environmental variable `DATALAB_PRIVATE_LOC` that you can use to

--- a/docs/SDK/add_new_datasets_into_web_platform.md
+++ b/docs/SDK/add_new_datasets_into_web_platform.md
@@ -2,18 +2,16 @@
 
 DataLab provides an API which users can use to upload their own datasets into the DataLab web platform (privately or
 publicly) so that:
+
 * more deep analysis (bias, artifacts) could be made on the dataset in an interactive way
 * you can compare your dataset with existing similar ones to understand their own characteristics
 * more researcher will know your datasets
-
-
 
 This involves two steps:
 
 #### (1) Write a data loader script for your new dataset. You can refer to [`how to add new datasets into sdk`](https://github.com/ExpressAI/DataLab/blob/main/docs/add_new_datasets.md)
 
-#### (2) Create an account at DataLab [web platform](https://datalab.nlpedia.ai/user).
-
+#### (2) Create an account at DataLab [web platform](https://datalab.nlpedia.ai/user)
 
 #### (3) Call the client function to add your dataset
 
@@ -38,20 +36,21 @@ client = Client(
 )
 client.add_dataset_from_sdk() # if you could successfully run this, you can find the dataset here: https://datalab.nlpedia.ai/datasets_explore/user_dataset
 ```
+
 where
+
 * `dataset_name_db`: denotes the name of the dataset to be stored in the database. You can specify any name based on your preference
 * `dataset_name_sdk`: denotes your dataset's data loader script path.
 * `feature_func`: is used to calculate sample-level (e.g., text length) and dataset-level features (e.g., the average of text length), which are usually
- task-dependent. 
-    * DataLab provide [some templates](https://github.com/ExpressAI/DataLab/blob/main/client/example_funcs.py) for four types of task. You can either use them directly or develop new ones based on them.
-    * Usually, the process of feature calculation will take some time.
-    * We also provide a [template script](https://github.com/ExpressAI/DataLab/blob/main/client/add_my_dataset.py) for adding your dataset into web platform, feel free to instantiate it based on your needs.
-    * If your dataset is too large (>200M), please contact us.
-    
-    
-#### (4) View your dataset in DataLab web platform
-Once you successfully finished the above steps,  you can find the dataset 
-in your [private space]((https://datalab.nlpedia.ai/datasets_explore/user_dataset)) of DataLab web.
+ task-dependent.
+  * DataLab provide [some templates](https://github.com/ExpressAI/DataLab/blob/main/client/example_funcs.py) for four types of task. You can either use them directly or develop new ones based on them.
+  * Usually, the process of feature calculation will take some time.
+  * We also provide a [template script](https://github.com/ExpressAI/DataLab/blob/main/client/add_my_dataset.py) for adding your dataset into web platform, feel free to instantiate it based on your needs.
+  * If your dataset is too large (>200M), please contact us.
 
+#### (4) View your dataset in DataLab web platform
+
+Once you successfully finished the above steps,  you can find the dataset
+in your [private space]((https://datalab.nlpedia.ai/datasets_explore/user_dataset)) of DataLab web.
 
 #### (5) Make your dataset Public (Optional)

--- a/docs/SDK/add_new_task_schema.md
+++ b/docs/SDK/add_new_task_schema.md
@@ -1,9 +1,5 @@
 # How to add a new task schema for your dataset?
 
-
-
-
-
 This will happen when you aim to add a new dataset whose task schema has NOT been supported by existing tasks schemas. In this case, you need to mannually add a new task schema.
 Here are existing supported [task schema](https://github.com/ExpressAI/DataLab/tree/main/src/datalabs/tasks)
 
@@ -14,20 +10,18 @@ Here are existing supported [task schema](https://github.com/ExpressAI/DataLab/t
 Suppose that we want to add the `sequence-labeling` as a new task schema, which requires three steps:
 
 ##### 1. creat a script for the class
+
 We need to creat a script (`sequence_labeling.py`) in the [folder](https://github.com/ExpressAI/DataLab/tree/main/src/datalabs/tasks) to claim the class [`SequenceLabeling`](https://github.com/ExpressAI/DataLab/blob/main/src/datalabs/tasks/sequence_labeling.py).
 
 ##### 2. claim the new class in `__init__.py`
+
 We then need to register the information of new class at [`__init__.py`](https://github.com/ExpressAI/DataLab/blob/main/src/datalabs/tasks/__init__.py)
-
-
 
 ### Tips
 
 * The motivation of introducing task schema is to help us easily standardize (normalize) different datasets from the same task category.
 For example, the samples from both [`ag_news`](https://github.com/ExpressAI/DataLab/blob/main/datasets/ag_news/ag_news.py) (topic classification) and `sst2` (sentiment classification) should be [formatted as `text` and `label`](https://github.com/ExpressAI/DataLab/blob/da463705e983b771131c74ee5cef222d6d59d56e/src/datalabs/tasks/text_classification.py#L29). The advantage of doing this is we can easily process all datasets within this task category in a unified way (without any additional preprocessing).
 * Once we introduce a new task schema, we can first refer to the schema of similar tasks and incrementally extend it. (`incrementally` kinda means partially `inherit` the similar task schema.)
-For example, 
+For example,
 * you can refer to [QuestionAnsweringExtractive](https://github.com/ExpressAI/DataLab/blob/604656cdce05d539e94949f0c842fbbb5b368188/src/datalabs/tasks/question_answering.py#L9) if you aim to introduce other QA-based tasks.
 * you can refer to [Summarization](https://github.com/ExpressAI/DataLab/blob/604656cdce05d539e94949f0c842fbbb5b368188/src/datalabs/tasks/summarization.py#L22) if other new generation tasks are being added.
-
-

--- a/docs/SDK/how_to_create_a_benchmark.md
+++ b/docs/SDK/how_to_create_a_benchmark.md
@@ -6,25 +6,28 @@ to assess system performance, therefore tracking the technical progress in some 
 This document details how to build an interactive benchmark for your evaluation purpose.
 
 ### 1. Add your datasets to DataLab SDK
+
 The first step is to add all datasets involved in your benchmark into DataLab SDK by
 following the [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md)
 
-
 ### 2. Task implementation
-Check if the tasks for different datasets are supported by existing [ExplainaBoard SDK](https://github.com/neulab/ExplainaBoard/blob/7fb8ccd2b999f5eb831ebae6011cee2dfff393fe/explainaboard/constants.py#L4), 
+
+Check if the tasks for different datasets are supported by existing [ExplainaBoard SDK](https://github.com/neulab/ExplainaBoard/blob/7fb8ccd2b999f5eb831ebae6011cee2dfff393fe/explainaboard/constants.py#L4),
+
 * if all are supported, jump to the next step
 * if there is any task that hasn't been supported, then you need to add a new task into
-ExplainaBoard SDK by following this [doc](https://github.com/neulab/ExplainaBoard/blob/main/docs/add_new_tasks.md). If 
+ExplainaBoard SDK by following this [doc](https://github.com/neulab/ExplainaBoard/blob/main/docs/add_new_tasks.md). If
 you have any trouble in doing this, feel free to contact (e.g., open an issue) us.
 
 ### 3. Create a benchmark config file and make a pull request
+
 Once all datasets of the benchmark are added into DataLab SDK, and all tasks are supported by ExplainaBoard SDK,
 the next step is to create a config that defines
- * how the benchmark is composed of these datasets
- * what evaluation metrics would be used for each task
- 
-We will use an example to show what the config file looks like.
 
+* how the benchmark is composed of these datasets
+* what evaluation metrics would be used for each task
+
+We will use an example to show what the config file looks like.
 
 ```JSON
 {
@@ -75,9 +78,10 @@ We will use an example to show what the config file looks like.
       }
 ]
 }
-``` 
+```
 
-where 
+where
+
 * `id`: the identify of your benchmark.
 * `name`: benchmark name
 * `visibility`: this could be "public" or "private", suggesting if this benchmark could be observed in
@@ -85,18 +89,16 @@ the web platform.
 * `contact`: benchmark contact
 * `homepage`: homepage information of the benchmark
 * `datasets`: it's a list, where each element record the metadata information of a dataset.
-    * `dataset_name`: dataset name
-    * `sub_dataset`: sub_dataset name
-    * `dataset_split`: train|validation|test
-    * `metrics`: it is a list, where each element specifies a metric name
-    * `task`: task name
-    * `output_file_type`: the format of output file
+  * `dataset_name`: dataset name
+  * `sub_dataset`: sub_dataset name
+  * `dataset_split`: train|validation|test
+  * `metrics`: it is a list, where each element specifies a metric name
+  * `task`: task name
+  * `output_file_type`: the format of output file
 * `views`: this specifies the layout and aggregation strategies of benchmark when displayed in the web page.
 It could be a list, meaning that multiple aggregation ways are supported.
 
- 
  More examples could be found [here](https://github.com/neulab/explainaboard_web/tree/main/backend/src/impl/benchmark_configs)
- 
- 
+
 Once you have successfully created the benchmark config, you could set up a pull request at [ExplainaBoard Web](https://github.com/neulab/explainaboard_web/pulls)
 and put your config [here](https://github.com/neulab/explainaboard_web/tree/main/backend/src/impl/benchmark_configs).

--- a/docs/SDK/how_to_create_a_benchmark_zh.md
+++ b/docs/SDK/how_to_create_a_benchmark_zh.md
@@ -1,34 +1,33 @@
 # 如何快速构建一个可交互的多数据集评估基准？([最终实现效果](https://explainaboard.inspiredco.ai/benchmark))
 
-
 评估基准（Evaluation Benchmark）通常由多个典型数据集组成、用于
 评估系统性能从而追踪某些领域的技术进展的基准。典型的例子如GLUE, XTREME.
 
 本文档详细介绍了如何快速构建一个可交互的（e.g.,用户可以方便进行系统提交以及各种分析）、
 可定制化（评估指标的选用、不同任务权重的设计）的多数据集评估基准。
 
-
 ### 1. 添加数据集到 DataLab SDK
+
 第一步是按照[doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md)
 将基准测试中涉及的所有数据集添加到DataLab SDK中
-
 
 ### 2. 任务评估功能实现
 
 检查现有的[ExplainaBoard SDK](https://github.com/neulab/ExplainaBoard/blob/7fb8ccd2b999f5eb831ebae6011cee2dfff393fe/explainaboard/constants.py#L4)是否支持不同数据集的任务
+
 * 如果所有都支持，则跳转到下一步
 * 如果有任何任务不被支持，那么你需要通过这个[doc](https://github.com/neulab/ExplainaBoard/blob/main/docs/add_new_tasks.md)添加一个新的任务到ExplainaBoard SDK中
 。如果您在此过程中有任何困难，请随时与我们联系(例如，新建一个`issue`)。
- 
- 
-### 3. 创建一个基准配置文件 （benchmark config）并发出一个`pull request` 
+
+### 3. 创建一个基准配置文件 （benchmark config）并发出一个`pull request`
+
 将基准测试的所有数据集添加到DataLab SDK中，并且ExplainaBoard SDK支持所有任务之后，
 下一步是创建一个基准配置文件：
+
 * 基准是如何由这些数据集组成的
 * 每个任务将使用什么评估指标
- 
-我们将使用一个示例来展示配置文件的样子：
 
+我们将使用一个示例来展示配置文件的样子：
 
 ```JSON
 {
@@ -79,25 +78,24 @@
       }
 ]
 }
-``` 
+```
 
-where 
+where
+
 * `id`: 基准的id.
 * `name`: 基准的名字
 * `visibility`: 这可能是“private”或“public”，表明这个基准是否可以在网络平台上被观察到。
 * `contact`: 基准的联系人信息（一般写邮箱即可）
 * `homepage`: 基准的主页信息
 * `datasets`: 它是一个列表，其中每个元素记录数据集的元数据信息。
-    * `dataset_name`: dataset name
-    * `sub_dataset`: sub_dataset name
-    * `dataset_split`: train|validation|test
-    * `metrics`: it is a list, where each element specifies a metric name
-    * `task`: task name
-    * `output_file_type`: the format of output file
+  * `dataset_name`: dataset name
+  * `sub_dataset`: sub_dataset name
+  * `dataset_split`: train|validation|test
+  * `metrics`: it is a list, where each element specifies a metric name
+  * `task`: task name
+  * `output_file_type`: the format of output file
 * `views`: 这指定了基准测试在网页中显示时的布局和聚合策略。它可以是一个列表，这意味着支持多种聚合方式。
 
- 
 更多基准配置文件的[例子](https://github.com/neulab/explainaboard_web/tree/main/backend/src/impl/benchmark_configs)
- 
- 
+
 一旦您成功地创建了基准配置，可以在[ExplainaBoard Web](https://github.com/neulab/explainaboard_web/pulls)上发起一个pull request，并放置 [这里](https://github.com/neulab/explainaboard_web/tree/main/backend/src/impl/benchmark_configs).

--- a/docs/SDK/how_to_name_a_feature.md
+++ b/docs/SDK/how_to_name_a_feature.md
@@ -1,6 +1,6 @@
-# How to name a feature:
+# How to name a feature
 
-#### A. For general features:
+#### A. For general features
 
 If there are two general features:  gender_bias_name_female &&  lexical_richness
 
@@ -8,17 +8,17 @@ If there are one split :   train
 
 If there are two field:    text  && label
 
-##### 1. data set level:
+##### 1. data set level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 {field name}\_{split_name}\_avg_{feature name}
 
 Ex. text_train_avg_gender_bias_name_female
 
-##### 2. sample level:
+##### 2. sample level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 {field name}_{feature name}
 
@@ -26,23 +26,23 @@ Ex. text_gender_bias_name_female
 
 #### B.  ner
 
-There are four features: true_entity_info_of  && avg_span_length_of (dataset level)  &&  avg_eCon_of (dataset level)  &&  avg_eFre_of (dataset level) 
+There are four features: true_entity_info_of  && avg_span_length_of (dataset level)  &&  avg_eCon_of (dataset level)  &&  avg_eFre_of (dataset level)
 
 If there are one split :   train
 
 If there are two field:    tokens
 
-##### 1. data set level:
+##### 1. data set level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 {feature name}\_{field name}_{split name}
 
 Ex. avg_eFre_of_tokens_train
 
-##### 2. sample level:
+##### 2. sample level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 {feature name}_{field name}
 
@@ -56,9 +56,9 @@ If there are one split :   train
 
 There are three features: minus, add, divide
 
-##### 1. data set level:
+##### 1. data set level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 premise\_length\_minus_hypothesis_avg\_{split name}_length
 
@@ -68,9 +68,9 @@ premise\_length\_divide_hypothesis_avg\_{split name}_length
 
 Ex. premise\_length\_divide_hypothesis_avg\_train_length
 
-##### 2. sample level:
+##### 2. sample level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 premise\_length\_minus_hypothesis_length
 
@@ -86,9 +86,9 @@ If there are one split :   train
 
 There are bleu features:bleu, divide
 
-##### 1. data set level:
+##### 1. data set level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 question\_length\_divide_context\_avg\_{split name}_length
 
@@ -96,9 +96,9 @@ bleu_question_context_avg_{split name}
 
 Ex. premise\_length\_divide_hypothesis_avg\_train_length
 
-##### 2. sample level:
+##### 2. sample level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 question\_length\_divide_context_length
 
@@ -112,9 +112,9 @@ If there are one split :   train
 
 If the field of summary dataset are summary document
 
-##### 1. data set level:
+##### 1. data set level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 ```
 avg_density_of_{split}_{field0}_and_{field1}
@@ -142,9 +142,9 @@ avg_copy_length_of_{split}_{field0}_and_{field1}
 
 Ex.  avg_copy_length_of\_train\_summary\_and_document
 
-##### 2. sample level:
+##### 2. sample level
 
-The name of feature should follow this format: 
+The name of feature should follow this format:
 
 ```
 density_of_{field0}_and_{field1}
@@ -171,4 +171,3 @@ copy_length_of_{field0}_and_{field1}
 ```
 
 Ex. copy_length_of\_summary\_and_document
-

--- a/docs/SDK/how_to_preprocess_your_data.md
+++ b/docs/SDK/how_to_preprocess_your_data.md
@@ -1,11 +1,11 @@
 # How to Preprocess you Data?
 
-Data preprocessing (e.g., tokenization) is an indispensable step in training deep  learning and machine learning models, 
+Data preprocessing (e.g., tokenization) is an indispensable step in training deep  learning and machine learning models,
 and the quality of the dataset directly affects the learning of models. Currently, DataLab supports both general preprocessing functions
-and task-specific ones, which are built based on different sources, such as Spacy, NLTK and Huggingface. 
-
+and task-specific ones, which are built based on different sources, such as Spacy, NLTK and Huggingface.
 
 ## Interface
+
 ```python
 from datalabs import load_dataset
 from preprocess import *
@@ -26,13 +26,14 @@ res=dataset["test"].apply(lower, mode="local") # res:Dataset
 print(res)
 ```
 
-
 ## Supported Operations
+
 You can find more operations supported by DataLab SDK [here](http://datalab.nlpedia.ai/operations)
 
-
 ## Define your own Operations
+
 You can define the operation by yourself
+
 ```python
 from datalabs import load_dataset
 
@@ -44,7 +45,3 @@ dataset = load_dataset("ag_news")
 res=dataset["test"].apply(lower, mode = "realtime") # res:Iterator    
     
 ```
-
-
-
-

--- a/docs/SDK/how_to_save_processed_dataset.md
+++ b/docs/SDK/how_to_save_processed_dataset.md
@@ -2,13 +2,9 @@
 
 DataLab provides different modes for saving processed datasets. We will walk through them using the `ag_new` as an example.
 
-
 (Note: the default mode is `realtime`.)
 
-
-
 ### 1: `realtime`
-
 
 ```python
 from datalabs import load_dataset
@@ -27,10 +23,7 @@ printed results:
 
 ```
 
-
-
 ### 2: `memory`
-
 
 ```python
 from datalabs import load_dataset
@@ -50,9 +43,7 @@ Dataset({
 """
 ```
 
-
 ### 3: `local`
-
 
 ```python
 from datalabs import load_dataset

--- a/docs/SDK/task_normalization.md
+++ b/docs/SDK/task_normalization.md
@@ -1,6 +1,6 @@
 # Progress
-List datasets which are supported by SDK and their associated information w.r.t task schema 
 
+List datasets which are supported by SDK and their associated information w.r.t task schema
 
 |Datasets|Updated Date|Task Schema|Normalized State|Comments|Constructor|
 |:---    |:---        |:---       |:---       |:---    |:---    |

--- a/docs/SDK/what_is_task_schema.md
+++ b/docs/SDK/what_is_task_schema.md
@@ -1,7 +1,6 @@
 # What is the `task schema`?
 
-
-We introduce the concept of `task schema` that defines the format of datasets belonging to this task. This is useful to 
+We introduce the concept of `task schema` that defines the format of datasets belonging to this task. This is useful to
 standardize the formats of datasets from the same task.
 For example, the schema of `text classification` task is:
 
@@ -16,6 +15,4 @@ while for `text-matching` task, its schema can be defined as:
 
 More detailed can refer to this [folder](https://github.com/ExpressAI/DataLab/tree/main/src/datalabs/tasks).
 
-
 Also, this doc details [how to add a new task schema](add_new_task_schema.md).
-

--- a/docs/Unification/README.md
+++ b/docs/Unification/README.md
@@ -16,8 +16,8 @@ This is the schema for text classification task.
 * dataset_name: dbpedia_14
 * sub_dataset: dbpedia_14
 * schema instantiation
-    * text_column: content
-    * label_column: label
+  * text_column: content
+  * label_column: label
 
 | Dataset name                                   | Subset                        | Text Column                | Label Column                                                                                                                                                                                                                                                               |
 |------------------------------------------------|-------------------------------|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -220,8 +220,6 @@ This is the schema for text classification task.
 | mr_upload_by_pf5                               | None                          | text                       | label                                                                                                                                                                                                                                                                      |
 | ag_news_test_yt_trrr                           | null                          | text                       | label                                                                                                                                                                                                                                                                      |
 
-
-
 ## [Summarization](https://github.com/ExpressAI/DataLab/blob/main/src/datalabs/tasks/summarization.py#L25)
 
 This is the schema for summarization task.
@@ -232,7 +230,6 @@ This is the schema for summarization task.
   "summary_column": "string"
 }
 ```
-
 
 | Dataset name         | Subset            | Text Column                        | Summary Column        |
 |----------------------|-------------------|------------------------------------|-----------------------|
@@ -297,5 +294,3 @@ This is the schema for summarization task.
 | reddit_tifu          | long              | text                               | summary               |
 | multi_xscience       | single-document   | text                               | summary               |
 | asap_review          | default           | text                               | review                |
-
-

--- a/docs/WebUI/10_analyzing_summarization_datasets.md
+++ b/docs/WebUI/10_analyzing_summarization_datasets.md
@@ -5,45 +5,51 @@ Datalab supports fine-grained analysis and comparision of summarization datasets
 ## Outline
 
 * ### [Supported Features](#supported-features-1)
+
 * ### [Supported Datasets](#supported-datasets-1)
+
 * ### [Examples](#examples-1)
-  * #### [CNNDM v.s. XSum](#comparing-cnndm-cnndailymail-and-xsum-datasets)
-  * #### [Multi-XScience v.s. DialogSum](#comparing-a-scientific-multi-document-summarization-dataset-multi-xscience-and-a-dialogue-summarization-dataset-dialogsum)
-  * #### [Reddit TIFU v.s. QMSum](#comparing-a-summarization-dataset-reddit-tifu-on-informal-crowd-generated-posts-and-a-query-based-meeting-summarization-dataset-qmsum)
+
+* #### [CNNDM v.s. XSum](#comparing-cnndm-cnndailymail-and-xsum-datasets)
+
+* #### [Multi-XScience v.s. DialogSum](#comparing-a-scientific-multi-document-summarization-dataset-multi-xscience-and-a-dialogue-summarization-dataset-dialogsum)
+
+* #### [Reddit TIFU v.s. QMSum](#comparing-a-summarization-dataset-reddit-tifu-on-informal-crowd-generated-posts-and-a-query-based-meeting-summarization-dataset-qmsum)
+
 ## Supported Features
 
 ### General Features
 
-- text length
-- ratio of basic words
-- lexcical richness (i.e. lexical diversity)
-- ...
+* text length
+* ratio of basic words
+* lexcical richness (i.e. lexical diversity)
+* ...
 
 ### Advanced Task-Specific Features
 
-- Density (Extractive Fragment Density)
-  - Introduced in [Grusky et al., 2018](https://aclanthology.org/N18-1065.pdf) 
-  - The density measure quantifies how well the word sequence of a summary can be described as a series of extractions.
-  - DENSITY(A, S) is the average length of the extractive fragment to which each word in the summary belongs.
-- Coverage (Extractive Fragment Coverage)
-  - Introduced in [Grusky et al., 2018](https://aclanthology.org/N18-1065.pdf) 
-  - The coverage measure quantifies the extent to which a summary is derivative of a text.
-  - COVERAGE(A, S) measures the percentage of words in the summary that are part of an extractive fragment with the article.
-- Compression (Compression Ratio)
-  - Introduced in [Grusky et al., 2018](https://aclanthology.org/N18-1065.pdf) 
-  - Summarizing with higher compression is challenging as it requires capturing more precisely the critical aspects of the article text.
-  - COMPRESSION is the word ratio between the article and summary.
-- Repetition
-  - The repetition ratio of the reference summaries.
-  - A large reprtition ratio may indicate redundency.
-  - Please refer to [See et al., 2017](https://aclanthology.org/P17-1099.pdf) for more details.
-- Novelty
-  - The ratio of content of reference summaries that are not in the source text.
-  - Novelty is correlated with both abstractivity and faithfulness.
-  - Please refer to [See et al., 2017](https://aclanthology.org/P17-1099.pdf), [Bommasani and Cardie, 2020](https://aclanthology.org/2020.emnlp-main.649.pdf), [Maynez et al., 2020](https://aclanthology.org/2020.acl-main.173.pdf) for more details.
-- Copy Length
-  - The average length of fragments of reference summaries that appear in the source text.
-  - Please refer to [Chen et al., 2020](https://aclanthology.org/2020.findings-emnlp.329.pdf), [Grusky et al., 2018](https://aclanthology.org/N18-1065.pdf) for more details.
+* Density (Extractive Fragment Density)
+  * Introduced in [Grusky et al., 2018](https://aclanthology.org/N18-1065.pdf)
+  * The density measure quantifies how well the word sequence of a summary can be described as a series of extractions.
+  * DENSITY(A, S) is the average length of the extractive fragment to which each word in the summary belongs.
+* Coverage (Extractive Fragment Coverage)
+  * Introduced in [Grusky et al., 2018](https://aclanthology.org/N18-1065.pdf)
+  * The coverage measure quantifies the extent to which a summary is derivative of a text.
+  * COVERAGE(A, S) measures the percentage of words in the summary that are part of an extractive fragment with the article.
+* Compression (Compression Ratio)
+  * Introduced in [Grusky et al., 2018](https://aclanthology.org/N18-1065.pdf)
+  * Summarizing with higher compression is challenging as it requires capturing more precisely the critical aspects of the article text.
+  * COMPRESSION is the word ratio between the article and summary.
+* Repetition
+  * The repetition ratio of the reference summaries.
+  * A large reprtition ratio may indicate redundency.
+  * Please refer to [See et al., 2017](https://aclanthology.org/P17-1099.pdf) for more details.
+* Novelty
+  * The ratio of content of reference summaries that are not in the source text.
+  * Novelty is correlated with both abstractivity and faithfulness.
+  * Please refer to [See et al., 2017](https://aclanthology.org/P17-1099.pdf), [Bommasani and Cardie, 2020](https://aclanthology.org/2020.emnlp-main.649.pdf), [Maynez et al., 2020](https://aclanthology.org/2020.acl-main.173.pdf) for more details.
+* Copy Length
+  * The average length of fragments of reference summaries that appear in the source text.
+  * Please refer to [Chen et al., 2020](https://aclanthology.org/2020.findings-emnlp.329.pdf), [Grusky et al., 2018](https://aclanthology.org/N18-1065.pdf) for more details.
 
 ## Supported Datasets
 
@@ -139,17 +145,13 @@ multilexsum | `tiny` | MultiDocSummarization | ```load_dataset("multilexsum", "t
 
 ## Examples
 
-### Comparing CNNDM (CNN/DailyMail) and XSum datasets 
-
+### Comparing CNNDM (CNN/DailyMail) and XSum datasets
 
 <img src="https://user-images.githubusercontent.com/51046084/155863520-5f08e2da-f791-47c3-95d6-a8802fb7e671.JPG" width="600"/>
 
-
 #### Advanced Features
 
-
 <img src="https://user-images.githubusercontent.com/51046084/155863546-e9b16929-629b-4e43-b61d-3822d4642d96.JPG" width="600"/>
-
 
 <!-- ![advance](https://user-images.githubusercontent.com/51046084/155863546-e9b16929-629b-4e43-b61d-3822d4642d96.JPG) -->
 
@@ -167,23 +169,20 @@ Compared with CNNDailyMail, XSum is more abstractive since it achieves high nove
 
 <img src="https://user-images.githubusercontent.com/51046084/155858866-d3a5eafe-a94e-4804-9a85-f99f5a4ad719.JPG" width="600"/>
 
-
-- Multi-XScience is longer than DialogSum in terms of both text length and summary length.
-- DialogSum contain more basic words than Multi-XScience, possibly because dialogues are from daily life while scientific papers contain more rare words.
+* Multi-XScience is longer than DialogSum in terms of both text length and summary length.
+* DialogSum contain more basic words than Multi-XScience, possibly because dialogues are from daily life while scientific papers contain more rare words.
 
 #### Advanced Features
 <!-- ![advance](https://user-images.githubusercontent.com/51046084/155859135-b85350c9-4e47-4cc3-b6f4-82e8dfc71e6d.JPG) -->
 
 <img src="https://user-images.githubusercontent.com/51046084/155859135-b85350c9-4e47-4cc3-b6f4-82e8dfc71e6d.JPG" width="600"/>
 
-- Multi-Science is more abstractive since it contains more novel words
-- DialogSum is more extractive since it has higher density, coverage and copy length, which means more content in the summaries can be extracted from the source text.
+* Multi-Science is more abstractive since it contains more novel words
+* DialogSum is more extractive since it has higher density, coverage and copy length, which means more content in the summaries can be extracted from the source text.
 
 ### Comparing a summarization dataset (Reddit TIFU) on informal crowd-generated posts and a query-based meeting summarization dataset (QMSum)
 
-
 <!-- ![name](https://user-images.githubusercontent.com/51046084/155859674-e3c805a7-c753-4838-a32b-d549077a5dac.JPG) -->
-
 
 <img src="https://user-images.githubusercontent.com/51046084/155859674-e3c805a7-c753-4838-a32b-d549077a5dac.JPG" width="600"/>
 
@@ -202,10 +201,4 @@ A salient difference between these two datasets is that QMSum is much longer tha
 
 <!-- ![advance](https://user-images.githubusercontent.com/51046084/155859951-4cce92ed-0b12-4db3-89b6-77031b519491.JPG) -->
 
-The advanced features indicate that QMSum is more extractive while Reddit TIFU contains more novel words. As a result, it is likely that QMSum's summaries are more faithful than Reddit, since more content of QMSum's summaries can be direcly recovered in the source test. This observation suggests that the query-based collection protocal of QMSum can improve the faithfulness of reference summaries, which is one of the goals of this dataset. 
-
-
-
-
-
-
+The advanced features indicate that QMSum is more extractive while Reddit TIFU contains more novel words. As a result, it is likely that QMSum's summaries are more faithful than Reddit, since more content of QMSum's summaries can be direcly recovered in the source test. This observation suggests that the query-based collection protocal of QMSum can improve the faithfulness of reference summaries, which is one of the goals of this dataset.

--- a/docs/WebUI/1_browse_dataset_in_web_platform.md
+++ b/docs/WebUI/1_browse_dataset_in_web_platform.md
@@ -1,41 +1,24 @@
 # How to Browse Different forms of Data in DataLab Web Platform?
 
-
 One of the major characteristics of interacting with Datalab is that when you select an icon for a dataset, **you can click the right mouse button to trigger
 a shortcut menu for various actions**.
 
-For example, 
-
+For example,
 
 ### 1. You can first enter into the dataset [browsing page](http://datalab.nlpedia.ai/datasets_explore/text_dataset)
 
-
-
 <img src="https://user-images.githubusercontent.com/59123869/155355305-96578e9b-87f0-4f3f-8858-1f6aa040c779.png" width="600"/>
 
-
-### 2. Choose different forms of data based on your interest.
-
+### 2. Choose different forms of data based on your interest
 
 DataLab devises a general typology for the concepts of data as shown in the following figure. Different typologies of data will be expected to have diverse schema and will be equipped with different data operations.
 
 So far, DataLab mainly focuses on the `text dataset` but are trying to include more, for example, `scientific papers` and `structured text data`.
 
-
 <img src="https://user-images.githubusercontent.com/59123869/155357470-8b95671c-d5e4-45bb-9edf-076d33c1e6f2.png" width="600"/>
-
-
 
 ### 3. Click the right mouse button on your interested datasets
 
-
 <img src="https://user-images.githubusercontent.com/59123869/155357638-a5c07d55-50a7-44ab-9deb-24fd8694c33d.png" width="600"/>
 
-
-
-
-
-
 Congratulation! So far, you have managed how to play with data using DataLab.
-
-

--- a/docs/WebUI/2_fine_grained_analysis_of_a_dataset.md
+++ b/docs/WebUI/2_fine_grained_analysis_of_a_dataset.md
@@ -1,30 +1,21 @@
 # How to Get more Fine-grained Information of a Dataset?
 
-
 Fine-grained analysis aims to answer the question: **what are the characteristics of a dataset?**
 Conceptually, each data point (i.e. sample-level) or whole dataset (i.e. dataset-level) can be characterized from different dimensions.
 These are either generic (`text length` at sample-level or `the average text length` at corpus-level) or task-specific
 (for summarization: `summary compression` `the average of summary compression`)
 
-
-One key contribution of DataLab is that we not only design rich sample-level and dataset-level features, 
+One key contribution of DataLab is that we not only design rich sample-level and dataset-level features,
 but also compute and store those features in a database for easy browsing. For example, so far, we have designed more than 300 features
 and computed features for 140M samples.
 
-
-
-
 ## Dataset-level Analysis
-
 
 ### 1. Choose a dataset and click the `overview` button
 
 <img src="https://user-images.githubusercontent.com/59123869/155372937-3400e723-b302-4fa4-96a4-e39825073e75.png" width="200"/>
- 
-
 
 ### 2. You can see a bunch of dataset-level information that DataLab generates for you
-
 
 <img src="https://user-images.githubusercontent.com/59123869/155373748-5ce1111d-907f-4501-9c00-539d3a4f6581.png" width="600"/>
 
@@ -34,17 +25,14 @@ when writing a paper, we usually need some table like this, using DataLab, you c
 
 <img src="https://user-images.githubusercontent.com/59123869/155373996-a4504ee2-0044-4c46-911b-117824696bca.png" width="600"/>
 
-
 ### 3. Make your contribution
+
 DataLab has devised a comprehensive schema for each dataset based on [Data Statement](https://aclanthology.org/Q18-1041/), [LREC Database](https://lrec2020.lrec-conf.org/en/shared-lrs/), [Huggingface](https://huggingface.co/docs/datasets/), and [Paperswithcode](https://paperswithcode.com/).
-Regarding some important information that required community wisdom, DataLab is positioned as a crowdsourceable platform and any researcher can contribute to by directly 
+Regarding some important information that required community wisdom, DataLab is positioned as a crowdsourceable platform and any researcher can contribute to by directly
 editting the form.
 For example:
 
 <img src="https://user-images.githubusercontent.com/59123869/155375250-17772f8c-ff32-45a0-8b96-353b03848241.png" width="600"/>
-
-
-
 
 ## Sample-level Analysis
 
@@ -52,44 +40,25 @@ For example:
 
 <img src="https://user-images.githubusercontent.com/59123869/155375407-be78af20-5214-4ff5-a50f-a9de5ba0400a.png" width="200"/>
 
-
-
 ### 2. Filter samples based on different features
+
 You can filter data samples based on different features. **Dont' forget click the `Confirm` button once you finalize some feature.**
 
 <img src="https://user-images.githubusercontent.com/59123869/155375881-9a43adc7-80dc-4a01-b730-31388690cd08.png" width="600"/>
 
 <img src="https://user-images.githubusercontent.com/59123869/155375992-385d37d1-1e17-455b-a4ad-b0195a22b8a9.png" width="200"/>
 
-
-
-
-
 ### 3. Browse samples
+
 In the middle of the page, you can examine detailed sample-level information of your filtered sample (the raw text together with a bunch of features, such as `text length`).
 
-
 ### 4. Analyze by Sample Distribution
+
 One cool thing that DataLab has done for you is to automatically generate a sample distribution based on different features that you're interested in.
 For example, the following chart shows the sample distribution over different text lengths.
 
 <img src="https://user-images.githubusercontent.com/59123869/155376801-b9b75821-9282-43b1-a09f-e795f462a52e.png" width="600"/>
 
-
- 
-
 You can choose more features:
 
 <img src="https://user-images.githubusercontent.com/59123869/155376959-53b638f7-6b20-4a09-b22e-43f4bc0a128a.png" width="600"/>
-
-
-
-
-
-
-
-
-
-
-
-

--- a/docs/WebUI/3_bias_analysis_for_hate_speech.md
+++ b/docs/WebUI/3_bias_analysis_for_hate_speech.md
@@ -1,41 +1,27 @@
 # How to Perform Hate Speech Analysis using DataLab
 
-
-
 DataLab supports different types of bias analyses for datasets and `hate speech` is one case.
 Specifically, given a dataset, DataLab can identify what percentage of samples contains hate speech words.
-Although deciding whether a sentence contains toxic language is a slightly complex task, which may involve the confounding effects of 
-dialect and the social identity of a speaker [Sap et al. (2019)](https://aclanthology.org/P19-1163.pdf), we make a first step by following [Davidson et al (2017)](https://aaai.org/ocs/index.php/ICWSM/ICWSM17/paper/view/15665), 
+Although deciding whether a sentence contains toxic language is a slightly complex task, which may involve the confounding effects of
+dialect and the social identity of a speaker [Sap et al. (2019)](https://aclanthology.org/P19-1163.pdf), we make a first step by following [Davidson et al (2017)](https://aaai.org/ocs/index.php/ICWSM/ICWSM17/paper/view/15665),
 classifying the samples into following categories:
+
 * `hate speech`
 * `offensive language`
 * `neither`
 
 We then calculate the ratio of samples in different categories.
 
-
 To perform this type of analysis:
 
 ### 1. Dataset Selection
+
 You just need to choose a dataset and click the right mouse button, and choose `analysis` -> `bias`, then you will enter into a page designed for bias analysis
 
 <img src="https://user-images.githubusercontent.com/59123869/155384702-9c7dc15b-036f-4ce4-906d-1258075dad8a.png" width="200"/>
-
-
- 
 
 ### 2. Choose the `hate speech` filter
 
 As shown below, different colors represent the proportions of samples with different categories (`hate speech`, `offensive language` and `neither`)
 
 <img src="https://user-images.githubusercontent.com/59123869/155385027-17d4246b-2551-4ce2-9d31-b6305433ad08.png" width="600"/>
-
-
- 
-
-
-
-
-
-
-

--- a/docs/WebUI/4_bias_analysis_for_gender_bias.md
+++ b/docs/WebUI/4_bias_analysis_for_gender_bias.md
@@ -2,25 +2,16 @@
 
 DataLab can be used for quantify the proportion of male words (or entities) to female words (or entities) given a  dataset.
 
-
-
-
 To perform this type of analysis:
 
 ### 1. Dataset Selection
+
 You just need to choose a dataset and click the right mouse button, and choose `analysis` -> `bias`, then you will enter into a page designed for bias analysis
 
 <img src="https://user-images.githubusercontent.com/59123869/155384702-9c7dc15b-036f-4ce4-906d-1258075dad8a.png" width="200"/>
-
-
- 
-
 
 ### 2. Choose the `gender bias` option in the drop-down box
 
 As shown below, different colors represent the proportions of samples with male words and female words.
 
-
 <img src="https://user-images.githubusercontent.com/59123869/155390945-6bd2fed7-beca-4cb6-b5a6-380287562da5.png" width="600"/>
-
- 

--- a/docs/WebUI/5_bias_analysis_for_artifacts.md
+++ b/docs/WebUI/5_bias_analysis_for_artifacts.md
@@ -1,40 +1,33 @@
 # How to Identify Dataset Artifacts Using DataLab?
 
-To give a little bit background about what artifacts are: 
-they are are unexpected features existing in dataset that could provide a shortcut for model learning. For example, suppose that we have a binary 
+To give a little bit background about what artifacts are:
+they are are unexpected features existing in dataset that could provide a shortcut for model learning. For example, suppose that we have a binary
 sentiment classification dataset, where
+
 * all shorter samples are labeled as positive
 * all longer samples are labeled as negative
-model learned such as dataset will have bad generalization ability to unseen datasets since, in the world, not all datasets are like this one. It's a `fake` feature, which we 
+model learned such as dataset will have bad generalization ability to unseen datasets since, in the world, not all datasets are like this one. It's a `fake` feature, which we
 call as `artifact`.
-
-
 
 The basic idea of artifact identification is to use PMI (Pointwise mutual information) to detect whether there
 is an association between **TWO** features (e.g., sentence length v.s category).
 
-For example, given two feature_i, and feature_j, a higher absolute value of PMI(feature_i, feature_j) 
-suggests: 
-* higher association between feature_i, and feature_j; 
+For example, given two feature_i, and feature_j, a higher absolute value of PMI(feature_i, feature_j)
+suggests:
+
+* higher association between feature_i, and feature_j;
 * a potential artifact pattern involving feature_i, and feature_j, (e.g., longer sentences tend to have a positive sentiment.)
 
-
 One famous example of examining artifacts from previous work is [Annotation Artifacts in Natural Language Inference Data](https://arxiv.org/pdf/1803.02324.pdf).
-Inspired by this work, we take [`snli`](http://datalab.nlpedia.ai/normal_dataset/617794bfb7314cb4146d2384/dataset_bias) dataset 
+Inspired by this work, we take [`snli`](http://datalab.nlpedia.ai/normal_dataset/617794bfb7314cb4146d2384/dataset_bias) dataset
 as one example and walk through how to identify potential artifacts of a dataset using DataLab.
- 
-
 
 ### Step 1: Find the dataset's artifact analysis page
+
 Navigate to the dataset by either (1) searching for it in the top bar, or (2) clicking the "Data" button on the front page and browsing to it.
 Click the `Bias` tab, and then under the "choose bias dimension" menu select `artifact identification`.
 
-
 <img src="https://user-images.githubusercontent.com/59123869/154880168-d6def7f6-2833-4665-a490-3cb09fd199d4.png" width="600"/>
-
-
- 
-
 
 ### Step 2: Select two feature fields
 
@@ -43,28 +36,21 @@ Here by `field`, we indicate basic piece of information in the example.
 For example, in natural language inference task, the `field` could be `premise`, `hypothesis`, and `label`.
 In text summarization task, the `field` could be `source` and `summary`.
 
-
 ### Step 3: Select two features
+
 Features are properties defined over the data of each field. For example,
 the `text length` could be a feature of the field `hypothesis`, or `label` itself could be a feature of the field `label`.
 
-
 <img src="https://user-images.githubusercontent.com/59123869/154881277-c1b1de9a-3a07-4446-8a2b-e9fbad161d75.png" width="600"/>
 
-
-
 ### Step 4: Interpret results
-Once we finished the above three steps, a visualized PMI matrix will be printed automatically:
- 
 
+Once we finished the above three steps, a visualized PMI matrix will be printed automatically:
 
 <img src="https://user-images.githubusercontent.com/59123869/154881323-0e614f18-571d-4340-b991-91e5b35f3f80.png" width="600"/>
 
-
-
 For example, in the above matrix, value in entry (i,j) represents the PMI(i,j).
 and `8.4~12.1 (count:10883)` shows that there are 10883 samples whose hypothesis lengths are in [8.4,12.1].
-
 
 One tip here is we can examine the entries with higher absolute value of PMI (i.e., darker color), suggesting a potential artifact pattern.
 
@@ -79,11 +65,12 @@ we have:
 * p(y) = n(x)/N = 16525/50000
 where n(x) represents the number of samples with feature x.
 We define
-* `actual number` as the actual number of samples with features x and y: N * P(x,y) 
-* `ideal count` as the number of samples with features x and y if they were independent: N * P(x) * P(y)
+* `actual number` as the actual number of samples with features x and y: N * P(x,y)
+* `ideal count` as the number of samples with features x and y if they were independent: N *P(x)* P(y)
 * `PMI` = log p(x,y)/(p(x)p(y))
 
 Then for each entry of the matrix, we can see one floating text box, showing following statistics:
+
 * `label` (neutral): one feature
 * `hypothesis_length` (8.4~12.1): another feature
 * `actual count`: the actual number of samples whose `label` is neutral and `hypothesis_length` is in [8.4~12.1].
@@ -92,9 +79,10 @@ Then for each entry of the matrix, we can see one floating text box, showing fol
 * `PMI`: the PMI value  
 
 From this PMI matrix, we can observe that:
-* when the length of hypothesis is larger than 8.4, PMI(label_neutral,length_hypothesis) >0.28, suggesting that "long hypotheses" tend to co-occur with 
+
+* when the length of hypothesis is larger than 8.4, PMI(label_neutral,length_hypothesis) >0.28, suggesting that "long hypotheses" tend to co-occur with
   the "neutral" label regardless of what the premises are.
-* when length_hypothesis ∈ [1,4.7], PMI(label_entailment,length_hypothesis) = 0.359, implying that "short hypotheses" tend to co-occur 
+* when length_hypothesis ∈ [1,4.7], PMI(label_entailment,length_hypothesis) = 0.359, implying that "short hypotheses" tend to co-occur
   with the label "entailment".
 
 The above is just one example, and we can identify more potential artifacts in a similar way based on different features provided by DataLab.

--- a/docs/WebUI/6_artifact_identification_examples_in_poplular_datasets.md
+++ b/docs/WebUI/6_artifact_identification_examples_in_poplular_datasets.md
@@ -1,10 +1,8 @@
 # More Artifact Identification Examples in Popular Datasets
 
-
-
 ## 1. Observations and conclusions of artifact identification with PMI on the SNLI
 
-[SNLI Artifact Identification Interface](http://datalab.nlpedia.ai/normal_dataset/617794bfb7314cb4146d2384/dataset_bias) shows an artifact identification analysis of the SNLI dataset between features (e.g. `length_{hypothesis}) ` and labels (`entailment`, `neutral` or `contradiction`). The main observations are summarized as follow:
+[SNLI Artifact Identification Interface](http://datalab.nlpedia.ai/normal_dataset/617794bfb7314cb4146d2384/dataset_bias) shows an artifact identification analysis of the SNLI dataset between features (e.g. `length_{hypothesis})` and labels (`entailment`, `neutral` or `contradiction`). The main observations are summarized as follow:
 
 <table>
     <tr>
@@ -77,10 +75,9 @@
     </tr>
 </table>
 
-* `hp` and `pm` denote `hypothesis` and `premise`, respectively. `len` is a function that computes the length of a sentence. 
+* `hp` and `pm` denote `hypothesis` and `premise`, respectively. `len` is a function that computes the length of a sentence.
 
-
-## 2. Observations and conclusions of artifact identification with PMI on the GLUE-SST2 
+## 2. Observations and conclusions of artifact identification with PMI on the GLUE-SST2
 
 [GLUE-SST2 Artifact Identification Interface](http://datalab.nlpedia.ai/normal_dataset/61a9bf6d304f8c55afdc12e9/dataset_bias) shows an artifact identification analysis of the GLUE-SST2 dataset between features(e.g. `length_{sentence}`) and labels (`positive` and `negtive`). The main observations are summarized as follow:
 
@@ -116,12 +113,9 @@
 
 * `len` is a function that computes the length of a sentence. `sent` denotes `sentence`.
 
-
 ## 3. Observations and conclusions of artifact identification with PMI on the DBpedia2014
 
 [DBpedia2014 Artifact Identification Interface](http://datalab.nlpedia.ai/normal_dataset/6177751c8795791d8d46916f/dataset_bias) shows an artifact identification analysis of the DBpedia2014 dataset between several features (e.g. `basic word` and `gender bias`) and labels (`educational institution`, `office holder`, `artist`, `althlete`). The main observations are summarized as follow:
-
-
 
 <table>
     <tr>
@@ -169,14 +163,9 @@
     </tr>
 </table>
 
-
-
-
 ## 4. Observations and conclusions of artifact identification with PMI on the GLUE-qnli
 
-
 [GLUE-qnli Artifact Identification Interface](http://datalab.nlpedia.ai/normal_dataset/6177751c8795791d8d46916f/dataset_bias) shows an artifact identification analysis of the GLUE-qnli dataset between several features (e.g. `basic word` and `gender bias`) and labels (`entailment`, `not-entailment`). The main observations are summarized as follow:
-
 
 <table>
     <tr>
@@ -226,4 +215,3 @@
 </table>
 
 * `len` is a function that computes the length of a sentence. `sent` denotes `sentence`.
-

--- a/docs/WebUI/7_compare_two_datasets.md
+++ b/docs/WebUI/7_compare_two_datasets.md
@@ -1,40 +1,23 @@
 # How to Compare Two Datasets in a more Fine-grained and Interactive way?
 
-
-
 When doing research, knowing the detailed differences between two datasets is important in multiple aspects, for example
+
 * it can help us explain the diverse behaviors of models training on different datasets
 * it can help us to choose a suitable one under a specific scenario
 However, analyzing their differences is tedious work, which usually needs to design different features and calculate them w.r.t to the datasets.
 
 DataLab automates this process and helps researchers to make pair-wise dataset analysis in a very convenient way. The general workflow is shown below:
 
-
 ### 1. Choose two datasets first
-
 
 <img src="https://user-images.githubusercontent.com/59123869/155394693-8577f69b-59ea-43c7-9222-e71edc105fd3.png" width="600"/>
 
-
- 
-
-
 ### 2. Click the right mouse button and choose the `compare`
- 
 
 <img src="https://user-images.githubusercontent.com/59123869/155394868-907abbd6-49dd-4455-85e6-c33c9a144c59.png" width="200"/>
 
-
-
-
-### 3. DataLab will generate different analytical figures and tables for these two datasets.
+### 3. DataLab will generate different analytical figures and tables for these two datasets
 
 <img src="https://user-images.githubusercontent.com/59123869/155395073-d1dfe0a2-8045-4b74-b78e-4a70729ea5f7.png" width="600"/>
 
 <img src="https://user-images.githubusercontent.com/59123869/155395692-6a610191-5588-4e82-881f-06df7adcb785.png" width="600"/>
-
-
- 
-
-
-

--- a/docs/WebUI/8_dataset_recommendation_based_on_idea.md
+++ b/docs/WebUI/8_dataset_recommendation_based_on_idea.md
@@ -1,20 +1,12 @@
 # I have an idea, which dataset should I use?
 
-
 An important question in practice is which datasets to use in a given scenario, given
 the huge proliferation of datasets in recent years. DataLab provides a semantic dataset search tool to help identify appropriate datasets.
 
-
 ### 1. Enter into the [`dataset finder`](http://datalab.nlpedia.ai/dataset_recommendation) page
 
-
 ### 2. Use natural language to describe your idea and type them in the text box. Click the button
+
 Then DataLab will generate a list of recommended datasets relevant to your research ideas.
 
-
 <img src="https://user-images.githubusercontent.com/59123869/155396781-b0407c8e-58c4-43f5-ad7b-1187d6211fe9.png" width="600"/>
-
-
- 
-
-

--- a/docs/WebUI/9_use_data_operations_to_process_your_data.md
+++ b/docs/WebUI/9_use_data_operations_to_process_your_data.md
@@ -1,88 +1,68 @@
 # How to use DataLab to Process your Data?
 
-
-Another key feature of DataLab is the standardization of different data operations into a unified 
+Another key feature of DataLab is the standardization of different data operations into a unified
 format to satisfy different data processing requirements in one place.
 To this end, we devised a general typology for the concepts of data and operation as shown below and curated schemas for these objects.
 
-
 <img src="https://user-images.githubusercontent.com/59123869/155357470-8b95671c-d5e4-45bb-9edf-076d33c1e6f2.png" width="600"/>
 
+Specifically, using [DataLab SDK](https://github.com/ExpressAI/DataLab), you can conveniently
 
-Specifically, using [DataLab SDK](https://github.com/ExpressAI/DataLab), you can conveniently 
 * process data with a unified interface
 * and use rich operations supported by SDK by passing different operation names
 
-
 <img src="https://user-images.githubusercontent.com/59123869/155447749-457820f2-d0e5-4426-acb2-17ea3bdff011.png" width="600"/>
 
- 
-
 You can install the SDK by:
+
 ```
 pip install --upgrade pip
 pip install datalabs
 ```
 
-
-
-So far, DataLab supports following types of data operations and implements some functions for each operation. Users can continue expanding 
+So far, DataLab supports following types of data operations and implements some functions for each operation. Users can continue expanding
 them by yourselves.
-
 
 ### Preprocessing
 
-Data preprocessing (e.g., tokenization) is an indispensable step in training deep  learning and machine learning models, 
+Data preprocessing (e.g., tokenization) is an indispensable step in training deep  learning and machine learning models,
 and the quality of the dataset directly affects the learning of models. Currently, DataLab supports both general preprocessing functions
 and task-specific ones, which are built based on different sources, such as Spacy, NLTK and Huggingface.
-
 
 <img src="https://user-images.githubusercontent.com/59123869/155447787-063de6fa-f6aa-4377-88d2-f985d5ff080c.png" width="600"/>
 
 ### Editing (Transformation)
-Editing aims to apply certain transformations to a given text, which spans multiple important applications in NLP, 
-for example 
+
+Editing aims to apply certain transformations to a given text, which spans multiple important applications in NLP,
+for example
+
 * adversarial evaluation [(Ribeiro et al., 2021)](https://arxiv.org/pdf/2005.04118.pdf), which usually requires diverse perturbations on test samples to test the robustness of a system.
-* data augmentation [(Dhole et al., 2021)](https://arxiv.org/pdf/2112.02721.pdf). 
+* data augmentation [(Dhole et al., 2021)](https://arxiv.org/pdf/2112.02721.pdf).
 Essentially, many of the methods for constructing augmented or diagnostic datasets involve some editing operation on the original dataset
   (e.g., named entity replacement in diagnostic dataset construction [(Ribeiro et al., 2021)](https://arxiv.org/pdf/2005.04118.pdf), token deletion in data augmentation [jason_2019](https://aclanthology.org/D19-1670.pdf).
 DataLab provides a unified interface for data editing and users can easily apply to edit the data they are interested in.
   
- 
-
-
 <img src="https://user-images.githubusercontent.com/59123869/155447848-794b6f94-e280-4874-953c-b7cfd02b2d65.png" width="600"/>
 
-
-  
 ### Featurizing
+
 This operation aims to compute sample-level features of a given text.
-In DataLab, in addition to designing some general feature functions (e.g. `*get_length()*` operation 
+In DataLab, in addition to designing some general feature functions (e.g. `*get_length()*` operation
 calculates the length of the text.), we also customize some feature functions for specific tasks (e.g. `*get_oracle()*`
 operation for the summarization task that calculates the oracle summary of the source text.).
 
- 
-
-
 <img src="https://user-images.githubusercontent.com/59123869/155447958-74deb639-8ff1-49cf-88fa-fa82439cc68c.png" width="600"/>
 
-
 ### Aggregating
-Aggregation operations are used to compute corpus-level statistics such as TF-IDF, 
+
+Aggregation operations are used to compute corpus-level statistics such as TF-IDF,
 label distribution. Currently, DataLab supports both generic aggregation operations applicable to any task and some customized ones
 for four NLP tasks (classification, summarization, extractive question answering and natural language inference).
 
-
-
-
 ### Prompting
 
-Prompt-based learning [Liu et al. 2021](https://arxiv.org/pdf/2107.13586.pdf) has received considerable attention, as better utilization of pretrained 
+Prompt-based learning [Liu et al. 2021](https://arxiv.org/pdf/2107.13586.pdf) has received considerable attention, as better utilization of pretrained
 language models benefits many NLP tasks.
-So far, DataLab includes different prompt templates  which can be applied to five types of tasks 
-(topic classification, sentiment classification, sentence entailment, 
+So far, DataLab includes different prompt templates  which can be applied to five types of tasks
+(topic classification, sentiment classification, sentence entailment,
 summarization, natural language inference).
-
-
-
-

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -3,25 +3,28 @@ sidebar_position: 1
 ---
 
 # Introduction
+
 [DataLab](http://datalab.nlpedia.ai/) is a unified platform that allows for NLP researchers to perform a number of data-related tasks in an efficient and easy-to-use manner. In particular, DataLab supports the following functionalities:
-<p align="left"> 
+<p align="left">
 <img src="https://github.com/ExpressAI/DataLab/raw/main/docs/Resources/figs/datalab_overview.png" width="300"/>
-</p> 
+</p>
 
 * **Data Diagnostics**: DataLab allows for analysis and understanding of data to uncover undesirable traits such as hate speech, gender bias, or label imbalance.
 * **Operation Standardization**: DataLab provides and standardizes a large number of data processing operations, including aggregating, preprocessing, featurizing, editing and prompting operations.
 * **Data Search**: DataLab provides a semantic dataset search tool to help identify appropriate datasets given a textual description of an idea.
 * **Global Analysis**: DataLab provides tools to perform global analyses over a variety of datasets.
 
-
-
 ## Installation
+
 DataLab can be installed from PyPi
+
 ```bash
 pip install --upgrade pip
 pip install datalabs
 ```
+
 or from the source
+
 ```bash
 # This is suitable for SDK developers
 pip install --upgrade pip
@@ -31,11 +34,8 @@ pip install .
 ```
 
 ## Getting started
+
 Here we give several examples to showcase the usage of DataLab. For more information, please refer to the corresponding sections in our [documentation](https://expressai.github.io/DataLab/).
-
-
-
-
 
 ```python
 # pip install datalabs
@@ -70,8 +70,7 @@ print(next(res))
 from aggregate.text_classification import *
 res = dataset["test"].apply(get_statistics)
 ```
- 
 
 ## Acknowledgment
-DataLab originated from a fork of the awesome [Huggingface Datasets](https://github.com/huggingface/datasets) and [TensorFlow Datasets](https://github.com/tensorflow/datasets). We highly thank the Huggingface/TensorFlow Datasets for building this amazing library. More details on the differences between DataLab and them can be found in the section
 
+DataLab originated from a fork of the awesome [Huggingface Datasets](https://github.com/huggingface/datasets) and [TensorFlow Datasets](https://github.com/tensorflow/datasets). We highly thank the Huggingface/TensorFlow Datasets for building this amazing library. More details on the differences between DataLab and them can be found in the section


### PR DESCRIPTION
This PR is the initial step in series of changes to lint Markdown files in pre-commit hook and CI. The basic idea and approach  are exactly same as neulab/ExplainaBoard#536. This PR adds the linter to pre-commit hook and CI. Also, applies auto-fix to Markdown files by running `pre-commit run markdownlint-cli2-fix --all-files`. Issues found by the linter, but require manual changes are suppressed by turning corresponding linter rules off. Following PRs will re-enable the rules by fixing relevant issues in Markdown.