### PR TITLE
Download OMW as documented in README.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install explainaboard
           pip install .
-          python -c "import nltk; nltk.download('omw-1.4')"
+          python -m nltk.downloader omw-1.4
       - name: Run tests with unittest
         run: python -m unittest discover
   format:


### PR DESCRIPTION
Currently, OMW is downloaded slightly differently in CI. This PR fixes the way to download the dataset in the same way as documented in `README.md`, which makes updating version or removing the command easier.