### PR TITLE
Clarify wmt20 is a dataset of a news translation task

### DIFF
--- a/datasets/wmt20/wmt20.py
+++ b/datasets/wmt20/wmt20.py
@@ -72,7 +72,7 @@ class WMT20(datalabs.GeneratorBasedBuilder):
             description=_DESCRIPTION,
             citation=_CITATION,
             # Homepage of the dataset for documentation
-            homepage="https://www.statmt.org/wmt20/translation-task.html"
+            homepage="https://www.statmt.org/wmt20/translation-task.html",
             # datasets.features.FeatureConnectors
             features=features_sample,
             supervised_keys=None,

--- a/datasets/wmt20/wmt20.py
+++ b/datasets/wmt20/wmt20.py
@@ -12,7 +12,7 @@ _CITATION = """
 
 
 _DESCRIPTION = """\
-WMT20 
+The recurring translation task of the WMT workshops focuses on news text.
 """
 
 _URL = "https://datalab-hub.s3.amazonaws.com/wmt20_test/{}/test.tsv"
@@ -72,7 +72,7 @@ class WMT20(datalabs.GeneratorBasedBuilder):
             description=_DESCRIPTION,
             citation=_CITATION,
             # Homepage of the dataset for documentation
-            homepage="https://www.statmt.org/wmt20/",
+            homepage="https://www.statmt.org/wmt20/translation-task.html"
             # datasets.features.FeatureConnectors
             features=features_sample,
             supervised_keys=None,


### PR DESCRIPTION
[WMT20](https://www.statmt.org/wmt20/) had multiple shared tasks. wmt20 dataset added in #369 doesn't tell the source information of the dataset. It's better to mention that it is a dataset of news translation task to avoid confusion.