### PR TITLE
Update homepage of CommonsenseQA

### DIFF
--- a/datasets/commonsense_qa/commonsense_qa.py
+++ b/datasets/commonsense_qa/commonsense_qa.py
@@ -78,7 +78,7 @@ class CommonsenseQa(datalabs.GeneratorBasedBuilder):
             # builder.as_dataset.
             supervised_keys=None,
             # Homepage of the dataset for documentation
-            homepage="https://www.tau-datasets.org/commonsenseqa",
+            homepage="https://www.tau-nlp.sites.tau.ac.il/commonsenseqa",
             citation=_CITATION,
             task_templates=[
                 get_task(TaskType.qa_multiple_choice_without_context)(


### PR DESCRIPTION
Currently, the homepage of CommonsenseQA is not reachable, because the homepage has moved to a different domain. This PR updates the homepage.